### PR TITLE
P2P モードで画面を開いているときに終了するとセグフォが起きていたのを修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,10 +184,11 @@ int main(int argc, char* argv[])
           server.get(), rtc_manager.get(), ws_client.get(), cs));
   }
 
-  std::unique_ptr<P2PServer> p2p_server;
+  std::unique_ptr<P2PHandlerProxy> p2p_handler_proxy;
+  std::shared_ptr<P2PServer> p2p_server;
   if (p2p_app->parsed()) {
-    p2p_server.reset(new P2PServer(
-            server.get(), rtc_manager.get(), cs));
+    p2p_handler_proxy.reset(new P2PHandlerProxy());
+    p2p_server = P2PServer::create(server.get(), p2p_handler_proxy.get(), rtc_manager.get(), cs);
   }
 
   _signal_waiter.wait_until_running();
@@ -195,6 +196,8 @@ int main(int argc, char* argv[])
   p2p_server = nullptr;
   sora_server = nullptr;
   server = nullptr;
+  // p2p_handler_proxy は必ず CivetServer より後に消すこと
+  p2p_handler_proxy = nullptr;
   ws_client = nullptr;
   rtc_manager = nullptr;
 

--- a/src/p2p/p2p_handler_proxy.cpp
+++ b/src/p2p/p2p_handler_proxy.cpp
@@ -1,0 +1,40 @@
+#include "p2p_handler_proxy.h"
+
+void P2PHandlerProxy::setHandler(std::shared_ptr<CivetWebSocketHandler> handler) {
+  weak_handler_ = handler;
+}
+
+bool P2PHandlerProxy::handleConnection(CivetServer *server, const struct mg_connection *conn) {
+  auto handler = weak_handler_.lock();
+  if (handler) {
+    return handler->handleConnection(server, conn);
+  } else {
+    return CivetWebSocketHandler::handleConnection(server, conn);
+  }
+}
+
+void P2PHandlerProxy::handleReadyState(CivetServer *server, struct mg_connection *conn) {
+  auto handler = weak_handler_.lock();
+  if (handler) {
+    return handler->handleReadyState(server, conn);
+  } else {
+    return CivetWebSocketHandler::handleReadyState(server, conn);
+  }
+}
+
+bool P2PHandlerProxy::handleData(CivetServer *server, struct mg_connection *conn, int bits, char *data, size_t data_len) {
+  auto handler = weak_handler_.lock();
+  if (handler) {
+    return handler->handleData(server, conn, bits, data, data_len);
+  } else {
+    return CivetWebSocketHandler::handleData(server, conn, bits, data, data_len);
+  }
+}
+void P2PHandlerProxy::handleClose(CivetServer *server, const struct mg_connection *conn) {
+  auto handler = weak_handler_.lock();
+  if (handler) {
+    return handler->handleClose(server, conn);
+  } else {
+    return CivetWebSocketHandler::handleClose(server, conn);
+  }
+}

--- a/src/p2p/p2p_handler_proxy.h
+++ b/src/p2p/p2p_handler_proxy.h
@@ -1,0 +1,34 @@
+#ifndef P2P_HANDLER_PROXY_H_
+#define P2P_HANDLER_PROXY_H_
+
+// CivetServer の WebSocket ハンドラのプロキシ
+//
+// CivetServer の WebSocket ハンドラは、最低でも CivetServer と同じライフタイムじゃないといけないので、
+// 先に本物のハンドラが死んでもダミーとして動き続けるようにする。
+
+#include <memory>
+#include "CivetServer.h"
+
+class P2PHandlerProxy : public CivetWebSocketHandler
+{
+public:
+  void setHandler(std::shared_ptr<CivetWebSocketHandler> handler);
+
+  // CivetWebSocketHandler
+  bool handleConnection(CivetServer *server,
+                        const struct mg_connection *conn) override;
+  void handleReadyState(CivetServer *server,
+                        struct mg_connection *conn) override;
+  bool handleData(CivetServer *server,
+                  struct mg_connection *conn,
+                  int bits,
+                  char *data,
+                  size_t data_len) override;
+  void handleClose(CivetServer *server,
+                   const struct mg_connection *conn) override;
+
+private:
+  std::weak_ptr<CivetWebSocketHandler> weak_handler_;
+};
+
+#endif // P2P_HANDLER_PROXY_H_

--- a/src/p2p/p2p_server.cpp
+++ b/src/p2p/p2p_server.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #include "p2p_server.h"
+#include "p2p_handler_proxy.h"
 
 const std::string P2PServer::_url = "/ws";
 
@@ -8,11 +9,13 @@ P2PServer::P2PServer(
     CivetServer *server, RTCManager *rtc_manager, ConnectionSettings conn_settings) :
     _server(server), _rtc_manager(rtc_manager), _conn_settings(conn_settings)
 {
-  server->addWebSocketHandler(_url, this);
 }
 
-P2PServer::~P2PServer()
-{
+std::shared_ptr<P2PServer> P2PServer::create(CivetServer* server, P2PHandlerProxy* proxy, RTCManager* rtc_manager, ConnectionSettings conn_settings) {
+  std::shared_ptr<P2PServer> p2p_server(new P2PServer(server, rtc_manager, conn_settings));
+  proxy->setHandler(p2p_server);
+  server->addWebSocketHandler(_url, proxy);
+  return p2p_server;
 }
 
 std::shared_ptr<RTCConnection> P2PServer::createConnection(

--- a/src/p2p/p2p_server.h
+++ b/src/p2p/p2p_server.h
@@ -7,6 +7,7 @@
 #include "rtc/manager.h"
 #include "connection_settings.h"
 #include "p2p_connection.h"
+#include "p2p_handler_proxy.h"
 
 using json = nlohmann::json;
 
@@ -14,10 +15,10 @@ class P2PConnection;
 
 class P2PServer : public CivetWebSocketHandler
 {
+  P2PServer(CivetServer* server, RTCManager* rtc_manager, ConnectionSettings conn_settings);
+
 public:
-  P2PServer(CivetServer* server, RTCManager* rtc_manager,
-          ConnectionSettings conn_settings);
-  ~P2PServer();
+  static std::shared_ptr<P2PServer> create(CivetServer* server, P2PHandlerProxy* proxy, RTCManager* rtc_manager, ConnectionSettings conn_settings);
 
   std::shared_ptr<RTCConnection> createConnection(struct mg_connection *conn);
 


### PR DESCRIPTION
#1 の修正です。

原因は、CivetServer の終了時に、既に死んでいる P2PServer オブジェクトのハンドラを呼び出そうとしていたことでした。
このハンドラは CivetServer との WS 接続が確立した時点で固定されるため、P2PServer のデストラクタで `server->removeWebSocketHandler()` を呼び出しても意味がなく、外からハンドラを無効化することは出来ませんでした。

なのでハンドラのプロキシを用意して、P2PServer が死んでもダミーのハンドラが動くようにしました。