### PR TITLE
バイナリファイルサイズ削減対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,11 @@ SOURCE += $(CIVETWEB_LIB)
 # CLI11
 CFLAGS += -Ilibs/CLI11/include
 
+# package
+ifeq ($(BUILD_MODE),pkg)
+	PKG_OPTIONS += -s
+endif
+
 all: $(TARGET)
 
 $(IL_OBJECT): $(ILCLIENT_DIR)/%.o : $(ILCLIENT_DIR)/%.c
@@ -115,7 +120,7 @@ $(CIVETWEB_LIB):
 	cp $(CIVETWEB_DIR)/$(CIVETWEB_LIB) .
 
 $(TARGET): $(SOURCE)
-	$(CXX) -o $@ $(CFLAGS) $(INCLUDES) $^ $(LDFLAGS)
+	$(CXX) $(PKG_OPTIONS) -o $@ $(CFLAGS) $(INCLUDES) $^ $(LDFLAGS)
 
 clean:
 	rm -f *.o *.a $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ CFLAGS += -Ilibs/CLI11/include
 
 # package
 ifeq ($(BUILD_MODE),pkg)
-	PKG_OPTIONS += -s
+	LDFLAGS += -s
 endif
 
 all: $(TARGET)
@@ -120,7 +120,7 @@ $(CIVETWEB_LIB):
 	cp $(CIVETWEB_DIR)/$(CIVETWEB_LIB) .
 
 $(TARGET): $(SOURCE)
-	$(CXX) $(PKG_OPTIONS) -o $@ $(CFLAGS) $(INCLUDES) $^ $(LDFLAGS)
+	$(CXX) -o $@ $(CFLAGS) $(INCLUDES) $^ $(LDFLAGS)
 
 clean:
 	rm -f *.o *.a $(TARGET)

--- a/build/arm/armv6/Makefile
+++ b/build/arm/armv6/Makefile
@@ -19,7 +19,7 @@ all: clean
 	docker container create -it --name momo momo/webrtc-armv6:m$(WEBRTC_VERSION)
 	docker container start momo
 	docker container cp momo.tar.gz momo:/root/
-	docker container exec momo /bin/bash -c "cd /root && tar xf momo.tar.gz && cd momo && make USE_IL_ENCODER=$(USE_IL_ENCODER) ARCH=armv6"
+	docker container exec momo /bin/bash -c "cd /root && tar xf momo.tar.gz && cd momo && make USE_IL_ENCODER=$(USE_IL_ENCODER) ARCH=armv6 BUILD_MODE=$(BUILD_MODE)"
 	docker container cp momo:/root/momo/momo .
 	docker container stop momo
 	docker container rm momo

--- a/build/arm/armv7/Makefile
+++ b/build/arm/armv7/Makefile
@@ -19,7 +19,7 @@ all: clean
 	docker container create -it --name momo momo/webrtc-armv7:m$(WEBRTC_VERSION)
 	docker container start momo
 	docker container cp momo.tar.gz momo:/root/
-	docker container exec momo /bin/bash -c "cd /root && tar xf momo.tar.gz && cd momo && make USE_IL_ENCODER=$(USE_IL_ENCODER)"
+	docker container exec momo /bin/bash -c "cd /root && tar xf momo.tar.gz && cd momo && make USE_IL_ENCODER=$(USE_IL_ENCODER) BUILD_MODE=$(BUILD_MODE)"
 	docker container cp momo:/root/momo/momo .
 	docker container stop momo
 	docker container rm momo

--- a/build/arm/armv8/Makefile
+++ b/build/arm/armv8/Makefile
@@ -19,7 +19,7 @@ all: clean
 	docker container create -it --name momo momo/webrtc-armv8:m$(WEBRTC_VERSION)
 	docker container start momo
 	docker container cp momo.tar.gz momo:/root/
-	docker container exec momo /bin/bash -c 'cd /root && tar xf momo.tar.gz && cd momo && make ARCH=arm64 OS=xenial RTC_ROOT=/root'
+	docker container exec momo /bin/bash -c 'cd /root && tar xf momo.tar.gz && cd momo && make ARCH=arm64 OS=xenial RTC_ROOT=/root BUILD_MODE=$(BUILD_MODE)'
 	docker container cp momo:/root/momo/momo .
 	docker container stop momo
 	docker container rm momo

--- a/build/x86_64/Makefile
+++ b/build/x86_64/Makefile
@@ -16,7 +16,7 @@ all: clean
 	docker container create -it --name momo momo/webrtc-x86_64:m$(WEBRTC_VERSION)
 	docker container start momo
 	docker container cp momo.tar.gz momo:/root/
-	docker container exec momo /bin/bash -c 'cd /root && tar xf momo.tar.gz && cd momo && make ARCH=x86_64'
+	docker container exec momo /bin/bash -c 'cd /root && tar xf momo.tar.gz && cd momo && make ARCH=x86_64 BUILD_MODE=$(BUILD_MODE)'
 	docker container cp momo:/root/momo/momo .
 	docker container stop momo
 	docker container rm momo


### PR DESCRIPTION
#5 の対応です。

momo バイナリ作成時に -s オプションを付与することでシンボルテーブルを削除してファイルサイズを小さくします。
make 時に BUILD_MODE=pkg を付与した場合は -s オプションを付与、BUILD_MODE=pkg を指定しない場合は既存と同様に -s なしでビルドするようにしています。

```
$ make armv8 BUILD_MODE=pkg
```

make 時に BUILD_MODE=pkg を指定しなけば、これまで通り -s オプションなしで momo バイナリを作成します。

```
$ make armv8
```