### PR TITLE
ontrack 発火時に track を追加するように変更

### DIFF
--- a/html/webrtc.js
+++ b/html/webrtc.js
@@ -74,9 +74,11 @@ function prepareNewConnection() {
     const peer = new RTCPeerConnection({ "iceServers": [{ "url": "stun:stun.l.google.com:19302" }] });
 
     if ('ontrack' in peer) {
+        let mediaStream = new MediaStream();
+        playVideo(remoteVideo, mediaStream);
         peer.ontrack = function (event) {
             console.log('-- peer.ontrack()');
-            playVideo(remoteVideo, event.streams[0]);
+            mediaStream.addTrack(event.track);
         };
     }
     else {


### PR DESCRIPTION
#17 の対応です。

video と audio の両方を配信する場合に、後から発火した ontrack の stream のみがブラウザで再生されるようになっていたため、最初に共通の stream を作成して ontrack の発火時に track のみを追加するように変更しました。