### PR TITLE
パッケージ名とビルドターゲット名の整理

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -67,11 +67,11 @@ ubuntu-1804_x86_64:
 	# 生成されたバイナリをこのディレクトリに移動
 	mv x86_64/momo ./momo-ubuntu-18.04_x86_64-m$(WEBRTC_VERSION)-$(BUILD_NUMBER)
 
-.PHONY: x86_64_ros
-x86_64_ros:
+.PHONY: ubuntu-1604_x86_64_ros
+ubuntu-1604_x86_64_ros:
 	# x86_64_ros 用ビルド
-	$(MAKE) -C $(TARGET) WEBRTC_VERSION=$(WEBRTC_VERSION) BUILD_NUMBER=$(BUILD_NUMBER) MOMO_VERSION=$(MOMO_VERSION)
-	mv $(TARGET)/momo ./momo-$(TARGET)-m$(WEBRTC_VERSION)-$(BUILD_NUMBER)
+	$(MAKE) -C x86_64_ros WEBRTC_VERSION=$(WEBRTC_VERSION) BUILD_NUMBER=$(BUILD_NUMBER) MOMO_VERSION=$(MOMO_VERSION)
+	mv x86_64_ros/momo ./momo-ubuntu-16.04_x86_64_ros-m$(WEBRTC_VERSION)-$(BUILD_NUMBER)
 
 .PHONY: macos
 macos:
@@ -90,7 +90,7 @@ define COPY
 
 endef
 
-pkg: armv6.pkg armv7.pkg armv8.pkg ubuntu-1804_x86_64.pkg x86_64_ros.pkg
+pkg: armv6.pkg armv7.pkg armv8.pkg ubuntu-1804_x86_64.pkg ubuntu-1804_x86_64_ros.pkg armv7_ros.pkg
 
 armv6.pkg:
 	mkdir momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv6
@@ -120,12 +120,19 @@ ubuntu-1804_x86_64.pkg:
 	tar czf momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64.tar.gz momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64
 	rm -rf momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64
 
-x86_64_ros.pkg:
-	mkdir momo-$(MOMO_VERSION)_ubuntu_x86_64_ros
-	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_ubuntu_x86_64_ros/))
-	cp $(lastword $(sort $(wildcard ./momo-x86_64_ros-*))) momo-$(MOMO_VERSION)_ubuntu_x86_64_ros/momo
-	tar czf momo-$(MOMO_VERSION)_ubuntu_x86_64_ros.tar.gz momo-$(MOMO_VERSION)_ubuntu_x86_64_ros
-	rm -rf momo-$(MOMO_VERSION)_ubuntu_x86_64_ros
+ubuntu-1604_x86_64_ros.pkg:
+	mkdir momo-$(MOMO_VERSION)_ubuntu-16.04_x86_64_ros
+	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_ubuntu-16.04_x86_64_ros/))
+	cp $(lastword $(sort $(wildcard ./momo-ubuntu-16.04_x86_64_ros-*))) momo-$(MOMO_VERSION)_ubuntu-16.04_x86_64_ros/momo
+	tar czf momo-$(MOMO_VERSION)_ubuntu-16.04_x86_64_ros.tar.gz momo-$(MOMO_VERSION)_ubuntu-16.04_x86_64_ros
+	rm -rf momo-$(MOMO_VERSION)_ubuntu-16.04_x86_64_ros
+
+armv7_ros.pkg:
+	mkdir momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros
+	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros/))
+	cp $(lastword $(sort $(wildcard ./momo-armv7_ros-*))) momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros/momo
+	tar czf momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros.tar.gz momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros
+	rm -rf momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros
 
 clean.pkg:
 	rm -rf momo-$(MOMO_VERSION)_*

--- a/build/Makefile
+++ b/build/Makefile
@@ -2,6 +2,8 @@ BUILD_NUMBER=$(shell date +"%Y%m%d%H%M%S")
 WEBRTC_VERSION=71
 MOMO_VERSION=18.10.2
 
+RASPBIAN_VERSION=stretch
+
 TARGET=$@
 
 .PHONY: all
@@ -48,13 +50,13 @@ armv7.clean:
 armv8.clean:
 	$(MAKE) -C arm/armv8 clean.image.all WEBRTC_VERSION=$(WEBRTC_VERSION)
 
-.PHONY: x86_64
-x86_64:
+.PHONY: ubuntu-1804_x86_64
+ubuntu-1804_x86_64:
 	# x86_64 用ビルド
-	$(MAKE) -C $(TARGET) WEBRTC_VERSION=$(WEBRTC_VERSION) BUILD_NUMBER=$(BUILD_NUMBER) MOMO_VERSION=$(MOMO_VERSION)
+	$(MAKE) -C x86_64 WEBRTC_VERSION=$(WEBRTC_VERSION) BUILD_NUMBER=$(BUILD_NUMBER) MOMO_VERSION=$(MOMO_VERSION)
 
 	# 生成されたバイナリをこのディレクトリに移動
-	mv $(TARGET)/momo ./momo-$(TARGET)-m$(WEBRTC_VERSION)-$(BUILD_NUMBER)
+	mv x86_64/momo ./momo-ubuntu-18.04_x86_64-m$(WEBRTC_VERSION)-$(BUILD_NUMBER)
 
 .PHONY: macos
 macos:
@@ -73,35 +75,35 @@ define COPY
 
 endef
 
-pkg: armv6.pkg armv7.pkg armv8.pkg x86_64.pkg
+pkg: armv6.pkg armv7.pkg armv8.pkg ubuntu-1804_x86_64.pkg
 
 armv6.pkg:
-	mkdir momo-$(MOMO_VERSION)_raspbian_armv6
-	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_raspbian_armv6/))
-	cp $(lastword $(sort $(wildcard ./momo-armv6-*))) momo-$(MOMO_VERSION)_raspbian_armv6/momo
-	tar czf momo-$(MOMO_VERSION)_raspbian_armv6.tar.gz momo-$(MOMO_VERSION)_raspbian_armv6
-	rm -rf momo-$(MOMO_VERSION)_raspbian_armv6
+	mkdir momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv6
+	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv6/))
+	cp $(lastword $(sort $(wildcard ./momo-armv6-*))) momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv6/momo
+	tar czf momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv6.tar.gz momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv6
+	rm -rf momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv6
 
 armv7.pkg:
-	mkdir momo-$(MOMO_VERSION)_raspbian_armv7
-	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_raspbian_armv7/))
-	cp $(lastword $(sort $(wildcard ./momo-armv7-*))) momo-$(MOMO_VERSION)_raspbian_armv7/momo
-	tar czf momo-$(MOMO_VERSION)_raspbian_armv7.tar.gz momo-$(MOMO_VERSION)_raspbian_armv7
-	rm -rf momo-$(MOMO_VERSION)_raspbian_armv7
+	mkdir momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv7
+	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv7/))
+	cp $(lastword $(sort $(wildcard ./momo-armv7-*))) momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv7/momo
+	tar czf momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv7.tar.gz momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv7
+	rm -rf momo-$(MOMO_VERSION)_raspbian-$(RASPBIAN_VERSION)_armv7
 
 armv8.pkg:
-	mkdir momo-$(MOMO_VERSION)_ubuntu_armv8
-	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_ubuntu_armv8/))
-	cp $(lastword $(sort $(wildcard ./momo-armv8-*))) momo-$(MOMO_VERSION)_ubuntu_armv8/momo
-	tar czf momo-$(MOMO_VERSION)_ubuntu_armv8.tar.gz momo-$(MOMO_VERSION)_ubuntu_armv8
-	rm -rf momo-$(MOMO_VERSION)_ubuntu_armv8
+	mkdir momo-$(MOMO_VERSION)_ubuntu-16.04_armv8
+	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_ubuntu-16.04_armv8/))
+	cp $(lastword $(sort $(wildcard ./momo-armv8-*))) momo-$(MOMO_VERSION)_ubuntu-16.04_armv8/momo
+	tar czf momo-$(MOMO_VERSION)_ubuntu-16.04_armv8.tar.gz momo-$(MOMO_VERSION)_ubuntu-16.04_armv8
+	rm -rf momo-$(MOMO_VERSION)_ubuntu-16.04_armv8
 
-x86_64.pkg:
-	mkdir momo-$(MOMO_VERSION)_ubuntu_x86_64
-	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_ubuntu_x86_64/))
-	cp $(lastword $(sort $(wildcard ./momo-x86_64-*))) momo-$(MOMO_VERSION)_ubuntu_x86_64/momo
-	tar czf momo-$(MOMO_VERSION)_ubuntu_x86_64.tar.gz momo-$(MOMO_VERSION)_ubuntu_x86_64
-	rm -rf momo-$(MOMO_VERSION)_ubuntu_x86_64
+ubuntu-1804_x86_64.pkg:
+	mkdir momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64
+	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64/))
+	cp $(lastword $(sort $(wildcard ./momo-ubuntu-18.04_x86_64-*))) momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64/momo
+	tar czf momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64.tar.gz momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64
+	rm -rf momo-$(MOMO_VERSION)_ubuntu-18.04_x86_64
 
 clean.pkg:
 	rm -rf momo-$(MOMO_VERSION)_*

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -45,10 +45,10 @@ $ make armv8
 
 ## Ubuntu 18.04 (x86_64) 向けバイナリを作成する
 
-build ディレクトリ以下で make x86_64 と打つことで Momo の Ubuntu 18.04 x86_64 向けバイナリが生成されます。
+build ディレクトリ以下で make ubuntu-1804_x86_64 と打つことで Momo の Ubuntu 18.04 x86_64 向けバイナリが生成されます。
 
 ```shell
-$ make x86_64
+$ make ubuntu-1804_x86_64
 ```
 
 ## macOS 10.14 または macOS 10.13

--- a/doc/USE_ROS.md
+++ b/doc/USE_ROS.md
@@ -51,11 +51,6 @@ $ rosrun usb_cam usb_cam_node _pixel_format:=mjpeg
 
 ### P2P で動作を確認する
 
-- 変更可能なパラメータ
-  - image
-    - topic
-  - _port
-    - ポート番号  [0 - 65535]
 - 実行例
 
 ```shell
@@ -70,6 +65,12 @@ http://[momo の IP アドレス]:8080/html/p2p.html にアクセスしてくだ
 image は Web カメラから送られてくる画像データの topic を指定してください。
 
 - 変更可能なパラメータ
+  - image
+    - topic
+  - _port
+    - ポート番号  [0 - 65535]
+  - _log_level
+    - ログレベル  [0 - 5]
 
 
 ### WebRTC SFU Sora で動作を確認する


### PR DESCRIPTION
#32 の パッケージ名とビルドターゲット名の整理 の対応です。

```
momo-18.10.2_raspbian-stretch_armv6.tar.gz
    make armv6
momo-18.10.2_raspbian-stretch_armv7.tar.gz
    make armv7
momo-18.10.2_ubuntu-16.04_armv8.tar.gz
    make armv8
momo-18.10.2_ubuntu-18.04_x86_64.tar.gz
    make ubuntu-1804_x86_64
momo-18.10.2_ubuntu-16.04_armv7_ros.tar.gz
    make armv7_ros
momo-18.10.2_ubuntu-16.04_x86_64_ros.tar.gz
    make ubuntu-1604_x86_64_ros
```