### PR TITLE
macOS 10.14 x86_64 対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,10 @@ ifeq ($(UNAME),Linux)
 endif
 
 ifeq ($(UNAME),Darwin)
-	CFLAGS += -DWEBRTC_POSIX -DWEBRTC_MAC
-	LDFLAGS += -F/System/Library/Frameworks -ldl -framework Foundation -framework AVFoundation -framework CoreServices -framework CoreFoundation -framework AudioUnit -framework AudioToolbox -framework CoreAudio -framework CoreGraphics -framework CoreMedia -framework CoreVideo
-	LIBRTCCONDUCTOR = lib$(RTCCONDUCTOR)_mac.so
+	CFLAGS += -std=c++17 -DWEBRTC_POSIX -DWEBRTC_MAC
+	LDFLAGS += -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks -ldl -framework Foundation -framework AVFoundation -framework CoreServices -framework CoreFoundation -framework AudioUnit -framework AudioToolbox -framework CoreAudio -framework CoreGraphics -framework CoreMedia -framework CoreVideo
+	CFLAGS += -I$(BOOST_PATH)/include
+	LDFLAGS += -L$(BOOST_PATH)/lib
 endif
 
 ifdef ROS_VERSION

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ SOURCE += $(RTC_LIB)
 
 # boost
 CFLAGS += -I$(RTC_ROOT)/src/third_party/boringssl/src/include -DOPENSSL_IS_BORINGSSL
-LDFLAGS += -L$(RTC_LIB_PATH)/obj/third_party/boringssl -lboost_system -lboost_filesystem -lboringssl
+LDFLAGS += -L$(RTC_LIB_PATH)/obj/third_party/boringssl -lboost_filesystem -lboringssl
 
 # json
 CFLAGS += -Ilibs/json/include

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ ifeq ($(UNAME),Linux)
 endif
 
 ifeq ($(UNAME),Darwin)
-	CFLAGS += -std=c++17 -DWEBRTC_POSIX -DWEBRTC_MAC
+	CFLAGS += -DWEBRTC_POSIX -DWEBRTC_MAC
 	LDFLAGS += -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks -ldl -framework Foundation -framework AVFoundation -framework CoreServices -framework CoreFoundation -framework AudioUnit -framework AudioToolbox -framework CoreAudio -framework CoreGraphics -framework CoreMedia -framework CoreVideo
 	CFLAGS += -I$(BOOST_PATH)/include
 	LDFLAGS += -L$(BOOST_PATH)/lib

--- a/build/Makefile
+++ b/build/Makefile
@@ -134,5 +134,12 @@ armv7_ros.pkg:
 	tar czf momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros.tar.gz momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros
 	rm -rf momo-$(MOMO_VERSION)_ubuntu-16.04_armv7_ros
 
+macos.pkg:
+	mkdir momo-$(MOMO_VERSION)_macos
+	$(foreach filename,$(FILENAMES),$(call COPY,../$(filename),momo-$(MOMO_VERSION)_macos/))
+	cp $(lastword $(sort $(wildcard ./momo-macos-*))) momo-$(MOMO_VERSION)_macos/momo
+	tar czf momo-$(MOMO_VERSION)_macos.tar.gz momo-$(MOMO_VERSION)_macos
+	rm -rf momo-$(MOMO_VERSION)_macos
+
 clean.pkg:
 	rm -rf momo-$(MOMO_VERSION)_*

--- a/build/macos/.gitignore
+++ b/build/macos/.gitignore
@@ -3,4 +3,4 @@
 /.gclient
 /.gclient_entries
 /.cipd
-/boost
+/boost*

--- a/build/macos/.gitignore
+++ b/build/macos/.gitignore
@@ -3,4 +3,4 @@
 /.gclient
 /.gclient_entries
 /.cipd
-/boost*
+/boost_*

--- a/build/macos/.gitignore
+++ b/build/macos/.gitignore
@@ -2,3 +2,5 @@
 /src
 /.gclient
 /.gclient_entries
+/.cipd
+/boost

--- a/build/macos/Makefile
+++ b/build/macos/Makefile
@@ -39,10 +39,10 @@ $(LIBWEBRTC):
 	  create_pc_factory
 
 $(BOOST):
-	git clone https://github.com/boostorg/boost.git ./boost
+	curl -LO https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz && \
+	tar xf boost_1_69_0.tar.gz && \
+	rm boost_1_69_0.tar.gz && \
+	mv boost_1_69_0 boost && \
 	cd boost && \
-	git fetch && \
-	git checkout -b boost-1.69.0 && \
-	git submodule update --init --recursive && \
 	./bootstrap.sh && \
-	./b2 link=static install -j$(JOBS) --prefix=out
+	./b2 link=static variant=release install -j$(JOBS) --prefix=out --with-system --with-filesystem

--- a/build/macos/Makefile
+++ b/build/macos/Makefile
@@ -1,5 +1,7 @@
 LIBWEBRTC = src/out/x86_64/obj/libwebrtc.a
-BOOST = boost/out
+BOOST_VERSION = 1.69.0
+BOOST_PATH = boost_$(subst .,_,$(BOOST_VERSION))
+BOOST = $(BOOST_PATH)/out
 
 ifeq ($(JOBS),)
 	JOBS := $(shell system_profiler SPHardwareDataType | grep "Total Number of Cores" |  awk '{split($$0,ary,":");print ary[2]}' | xargs)
@@ -18,7 +20,7 @@ clean:
 	-rm -rf depot_tools/ > /dev/null 2>&1
 	-rm .gclient > /dev/null 2>&1
 	-rm .gclient_entries > /dev/null 2>&1
-	-rm -rf boost/ > /dev/null 2>&1
+	-rm -rf $(BOOST_PATH)/ > /dev/null 2>&1
 
 $(LIBWEBRTC):
 	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git ./depot_tools
@@ -39,10 +41,9 @@ $(LIBWEBRTC):
 	  create_pc_factory
 
 $(BOOST):
-	curl -LO https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz && \
-	tar xf boost_1_69_0.tar.gz && \
-	rm boost_1_69_0.tar.gz && \
-	mv boost_1_69_0 boost && \
-	cd boost && \
+	curl -LO https://dl.bintray.com/boostorg/release/$(BOOST_VERSION)/source/$(BOOST_PATH).tar.gz && \
+	tar xf $(BOOST_PATH).tar.gz && \
+	rm $(BOOST_PATH).tar.gz && \
+	cd $(BOOST_PATH) && \
 	./bootstrap.sh && \
 	./b2 link=static variant=release install -j$(JOBS) --prefix=out --with-system --with-filesystem

--- a/build/macos/Makefile
+++ b/build/macos/Makefile
@@ -46,4 +46,4 @@ $(BOOST):
 	rm $(BOOST_PATH).tar.gz && \
 	cd $(BOOST_PATH) && \
 	./bootstrap.sh && \
-	./b2 link=static variant=release install -j$(JOBS) --prefix=out --with-system --with-filesystem
+	./b2 visibility=global link=static variant=release install -j$(JOBS) --prefix=out --with-filesystem

--- a/build/macos/Makefile
+++ b/build/macos/Makefile
@@ -1,8 +1,16 @@
 LIBWEBRTC = src/out/x86_64/obj/libwebrtc.a
+BOOST = boost/out
+
+ifeq ($(JOBS),)
+	JOBS := $(shell system_profiler SPHardwareDataType | grep "Total Number of Cores" |  awk '{split($$0,ary,":");print ary[2]}' | xargs)
+	ifeq ($(JOBS),)
+		JOBS := 1
+	endif
+endif
 
 .PHONY: all
-all: $(LIBWEBRTC)
-	make -C ../../ OUT_PATH=x86_64 RTC_ROOT=build/macos MOMO_VERSION=$(MOMO_VERSION)
+all: $(LIBWEBRTC) $(BOOST)
+	make -C ../../ OUT_PATH=x86_64 RTC_ROOT=build/macos BOOST_PATH=build/macos/$(BOOST) MOMO_VERSION=$(MOMO_VERSION)
 
 .PHONY: clean
 clean:
@@ -10,6 +18,7 @@ clean:
 	-rm -rf depot_tools/ > /dev/null 2>&1
 	-rm .gclient > /dev/null 2>&1
 	-rm .gclient_entries > /dev/null 2>&1
+	-rm -rf boost/ > /dev/null 2>&1
 
 $(LIBWEBRTC):
 	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git ./depot_tools
@@ -28,3 +37,12 @@ $(LIBWEBRTC):
 	  builtin_video_encoder_factory \
 	  peerconnection \
 	  create_pc_factory
+
+$(BOOST):
+	git clone https://github.com/boostorg/boost.git ./boost
+	cd boost && \
+	git fetch && \
+	git checkout -b boost-1.69.0 && \
+	git submodule update --init --recursive && \
+	./bootstrap.sh && \
+	./b2 link=static install -j$(JOBS) --prefix=out

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -53,7 +53,55 @@ $ make ubuntu-1804_x86_64
 
 ## macOS 10.14 または macOS 10.13
 
-**現在準備中です**
+### 事前確認
+
+libwebrtc をビルドするためには、XCode をインストールし、最低１回は起動してライセンスに同意しておく必要があります。
+現時点では、開発ツールのスタンドアローンインストール（`/Library/Developer/CommandLineTools` にインストールされるもの）はサポートされていません。
+詳細は、次のリンク先をご覧ください。
+
+https://bugs.chromium.org/p/chromium/issues/detail?id=729990#c1
+
+開発マシンがどちらを使っているかは xcode-select --print-path で確かめることができます。
+XCode のものが利用されている場合は、次のような出力になります。
+
+```shell
+$ xcode-select --print-path
+/Applications/Xcode.app/Contents/Developer
+```
+
+ここでは AppStore から XCode をインストールしたケースを想定しています。
+もし XCode の beta 版をインストールしている場合は、`/Applications/Xcode.app` の部分を適宜読み替えてください。
+
+スタンドアローンインストールされたものが利用されている場合は、次のような出力になります。
+
+```shell
+$ xcode-select --print-path
+/Library/Developer/CommandLineTools
+```
+
+この場合、次のコマンドを入力し、ビルド前に使用される CLI のパスを切り替えてください。
+
+```shell
+$ sudo xcode-select -s /Applications/Xcode.app
+```
+
+また、libwebrtc のビルド中にいくつかの Python スクリプトが呼び出されますが、そこでは Python 2 系が入っていることが期待されています。
+macOS に同梱されている Python 以外の python を入れている場合は、バージョンを確認して、必要に応じてバージョンを切り替えておいてください。
+例えば `pyenv` を利用している場合は、ビルド前に system を利用するように指定し、Python 2 が利用されること確認してください。
+
+```shell
+$ pyenv local system
+$ python --version
+Python 2.7.10
+```
+
+### ビルド方法
+
+build ディレクトリ以下で make macos と打つことで Momo の macOS 向けバイナリが生成されます。
+
+```shell
+$ make macos
+```
 
 ## Windows 10
 


### PR DESCRIPTION
#12 macOS 10.14 x86_64 対応

次の環境でビルドできることを確認しました。

* macOS Mojave 10.14.2
* XCode 10.1
* MacBook Pro 15 インチ 2012 Mid

また、グローバルな開発環境への影響を最小限に抑える、という方針で実装しています。

* boost をソースからビルドして、作業フォルダー内にインストールしているのもこのためです
* boost のバージョンを固定できるようにという意味もあります
* `build/Makefile` の `pkg` ターゲットの依存関係に `macos.pkg` を入れていないのは意図的です。この PR はとりあえずビルド周りだけの対応で、全体のパッケージングには影響を与えないようにしました。必要なら追加します。

### 既知の問題

boost を静的にリンクすると以下のような warning が大量に出力されます。
`-fvisibility=hidden` オプションなども試してみたのですが、解消されませんでした。

```shell
ld: warning: direct access in function '__GLOBAL__sub_I_operations.cpp' from file 'build/macos/boost_1_69_0/out/lib/libboost_filesystem.a(operations.o)' to global weak symbol 'guard variable for boost::system::system_category()::system_category_instance' from file '/var/folders/py/wp9l88jx1zq3rm8ljdwxwvp00000gp/T/util-854fb9.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```
