### PR TITLE
RTCIceServers.url ではなく、RTCIceServers.urls を使う（Safari 12 対応を含む）

### DIFF
--- a/html/webrtc.js
+++ b/html/webrtc.js
@@ -106,8 +106,16 @@ function prepareNewConnection() {
         }
     };
 
-    peer.addTransceiver('video');
+    if (isUnifiedPlan(peer)) {
+        peer.addTransceiver('video');
+    }
+
     return peer;
+}
+
+function isUnifiedPlan(peer) {
+    const config = peer.getConfiguration();
+    return ('addTransceiver' in peer) && (!('sdpSemantics' in config) || config.sdpSemantics === "unified-plan");
 }
 
 function sendSdp(sessionDescription) {

--- a/html/webrtc.js
+++ b/html/webrtc.js
@@ -73,11 +73,11 @@ function prepareNewConnection() {
     const peer = new RTCPeerConnection({ "iceServers": [{ "urls": "stun:stun.l.google.com:19302" }] });
 
     if ('ontrack' in peer) {
-        let mediaStream = new MediaStream();
-        playVideo(remoteVideo, mediaStream);
         peer.ontrack = function (event) {
             console.log('-- peer.ontrack()');
+            let mediaStream = new MediaStream();
             mediaStream.addTrack(event.track);
+            playVideo(remoteVideo, mediaStream);
         };
     }
     else {
@@ -106,6 +106,7 @@ function prepareNewConnection() {
         }
     };
 
+    peer.addTransceiver('video');
     return peer;
 }
 

--- a/html/webrtc.js
+++ b/html/webrtc.js
@@ -70,7 +70,7 @@ function playVideo(element, stream) {
 }
 
 function prepareNewConnection() {
-    const peer = new RTCPeerConnection({ "iceServers": [{ "url": "stun:stun.l.google.com:19302" }] });
+    const peer = new RTCPeerConnection({ "iceServers": [{ "urls": "stun:stun.l.google.com:19302" }] });
 
     if ('ontrack' in peer) {
         let mediaStream = new MediaStream();


### PR DESCRIPTION
`RTCIceServers.url` は古い仕様なので、` RTCIceServers.urls` を使った方がいいと思います。
Safari 12 だと `TypeError: Member RTCIceServer.urls is required and must be an instance of (DOMString or sequence)` というエラーが出て動きません。

ちなみにこれを直しても、Safari 12 や現在 Technology Preview は PeerConnection 接続後に動画が表示されないのですが、これは別の問題です。（調査中）