### PR TITLE
httpsで接続した際にWebSocketもwssで接続する

### DIFF
--- a/html/webrtc.js
+++ b/html/webrtc.js
@@ -4,7 +4,7 @@ let peerConnection = null;
 let candidates = [];
 let hasReceivedSdp = false;
 
-const wsUrl = 'ws://' + location.host + '/ws';
+const wsUrl = ((location.protocol === 'https:') ? 'wss://' : 'ws://') + location.host + '/ws';
 const ws = new WebSocket(wsUrl);
 ws.onopen = function (evt) {
     console.log('ws open()');


### PR DESCRIPTION
ngrok等で外部からhttpsで繋ぐ際、WebSocketの接続が `ws://` のままなのでエラーが出ます。
この変更によって、httpで繋いだ際はws、httpsで繋いだ際はwssでWebSocketを繋ぐようになります。