### PR TITLE
Raspbian Buster 対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [UPDATE] Raspbian Buster に対応
+
 ## 19.07.0
 
 - [UPDATE] Raspberry Pi の H.264 を MMAL を利用したハードウェアエンコードに変更する

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include VERSION
 #   有効な値は linux, macos
 #
 # TARGET_OS_LINUX: TARGET_OS が linux の場合の詳細な OS の情報
-#   有効な値は raspbian-stretch, ubuntu-16.04, ubuntu-18.04
+#   有効な値は raspbian-buster, ubuntu-16.04, ubuntu-18.04
 #
 # TARGET_ARCH: ビルド対象の動作する CPU
 #   有効な値は x86_64, arm
@@ -44,27 +44,27 @@ include VERSION
 #
 # MOMO_LDFLAGS: C リンカーに追加で渡すフラグ。サニタイズフラグや追加のリンクオブジェクトを入れることを想定している。
 
-ifeq ($(PACKAGE_NAME),raspbian-stretch_armv6)
+ifeq ($(PACKAGE_NAME),raspbian-buster_armv6)
   TARGET_OS ?= linux
-  TARGET_OS_LINUX ?= raspbian-stretch
+  TARGET_OS_LINUX ?= raspbian-buster
   TARGET_ARCH ?= arm
   TARGET_ARCH_ARM ?= armv6
   USE_ROS ?= 0
   USE_MMAL_ENCODER ?= 1
   BOOST_ROOT ?= /root/boost-$(BOOST_VERSION)
   WEBRTC_SRC_ROOT ?= /root/webrtc/src
-  WEBRTC_LIB_ROOT ?= /root/webrtc-build/raspbian-stretch_armv6
+  WEBRTC_LIB_ROOT ?= /root/webrtc-build/raspbian-buster_armv6
   SYSROOT ?= /root/rootfs
-else ifeq ($(PACKAGE_NAME),raspbian-stretch_armv7)
+else ifeq ($(PACKAGE_NAME),raspbian-buster_armv7)
   TARGET_OS ?= linux
-  TARGET_OS_LINUX ?= raspbian-stretch
+  TARGET_OS_LINUX ?= raspbian-buster
   TARGET_ARCH ?= arm
   TARGET_ARCH_ARM ?= armv7
   USE_ROS ?= 0
   USE_MMAL_ENCODER ?= 1
   BOOST_ROOT ?= /root/boost-$(BOOST_VERSION)
   WEBRTC_SRC_ROOT ?= /root/webrtc/src
-  WEBRTC_LIB_ROOT ?= /root/webrtc-build/raspbian-stretch_armv7
+  WEBRTC_LIB_ROOT ?= /root/webrtc-build/raspbian-buster_armv7
   SYSROOT ?= /root/rootfs
 else ifeq ($(PACKAGE_NAME),ubuntu-16.04_armv7_ros)
   TARGET_OS ?= linux
@@ -263,7 +263,7 @@ ifeq ($(TARGET_OS),linux)
 
       # ilclient の設定
       ifeq ($(USE_MMAL_ENCODER),1)
-        ifeq ($(TARGET_OS_LINUX),raspbian-stretch)
+        ifeq ($(TARGET_OS_LINUX),raspbian-buster)
           VC_PATH = $(SYSROOT)/opt/vc
         else
           VC_PATH = $(SYSROOT)/usr

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ H.264 ハードウェアエンコーダーのライセンスが Raspberry Pi 以
 
 ## 動作環境
 
-- Raspbian Stretch ARMv7
+- Raspbian Buster ARMv7
     - Raspberry Pi 3 B/B+ で動作
-- Raspbian Stretch ARMv6
+- Raspbian Buster ARMv6
     - Raspberry Pi Zero W/WH で動作
 - Ubuntu 18.04 x86_64
 - Ubuntu 18.04 ARMv8

--- a/VERSION
+++ b/VERSION
@@ -9,8 +9,8 @@ CLI11_VERSION=1.8.0
 
 # パッケージ名の一覧
 PACKAGE_NAMES= \
-  raspbian-stretch_armv6 \
-  raspbian-stretch_armv7 \
+  raspbian-buster_armv6 \
+  raspbian-buster_armv7 \
   ubuntu-16.04_armv7_ros \
   ubuntu-18.04_armv8 \
   ubuntu-16.04_x86_64_ros \

--- a/VERSION
+++ b/VERSION
@@ -1,6 +1,6 @@
 # 各種ライブラリのバージョン情報
 # 項目を変更してビルドすれば各環境へ反映される（ように作る）
-MOMO_VERSION=19.07.0
+MOMO_VERSION=19.07.1
 WEBRTC_VERSION=76
 WEBRTC_COMMIT=d91cdbd2dd2969889a1affce28c89b8c0f8bcdb7
 BOOST_VERSION=1.70.0

--- a/doc/BUILD_LINUX.md
+++ b/doc/BUILD_LINUX.md
@@ -20,25 +20,25 @@ Windows の docker は未検証です。Linux 版、または macOS 版の Docke
 
 ## Raspbian June 2018 (armv6) 向けバイナリを作成する
 
-build ディレクトリ以下で make raspbian-stretch_armv6 と打つことで Momo のバイナリが生成されます。
+build ディレクトリ以下で make raspbian-buster_armv6 と打つことで Momo のバイナリが生成されます。
 
 ```shell
-$ make raspbian-stretch_armv6
+$ make raspbian-buster_armv6
 ```
 
-うまくいかない場合は `make raspbian-stretch_armv6.clean && make raspbian-stretch_armv6` を試してみてください。それでもだめな場合は issues にお願いします。
+うまくいかない場合は `make raspbian-buster_armv6.clean && make raspbian-buster_armv6` を試してみてください。それでもだめな場合は issues にお願いします。
 
 ## Raspbian June 2018 (armv7) 向けバイナリを作成する
 
 Raspberry Pi 3 B/B+ は実際は armv8 ですが 64 ビット機能が Raspbian では利用できないため、実質 armv7 相当のビルドになります。
 
-build ディレクトリ以下で make raspbian-stretch_armv7 と打つことで Momo のバイナリが生成されます。
+build ディレクトリ以下で make raspbian-buster_armv7 と打つことで Momo のバイナリが生成されます。
 
 ```shell
-$ make raspbian-stretch_armv7
+$ make raspbian-buster_armv7
 ```
 
-うまくいかない場合は `make raspbian-stretch_armv7.clean && make raspbian-stretch_armv7` を試してみてください。それでもだめな場合は issues にお願いします。
+うまくいかない場合は `make raspbian-buster_armv7.clean && make raspbian-buster_armv7` を試してみてください。それでもだめな場合は issues にお願いします。
 
 ## Ubuntu 18.04 (armv8) 向けバイナリを作成する
 

--- a/doc/PACKAGE.md
+++ b/doc/PACKAGE.md
@@ -2,18 +2,18 @@
 
 ## Raspbian June 2018 (armv6) 向けパッケージの作成例
 
-raspbian-stretch_armv6 パッケージを作成する場合は raspbian-stretch_armv6.package と打つことでパッケージが作成されます。
+raspbian-buster_armv6 パッケージを作成する場合は raspbian-buster_armv6.package と打つことでパッケージが作成されます。
 
 ```shell
-$ make raspbian-stretch_armv6.package
+$ make raspbian-buster_armv6.package
 ```
 
 パッケージは build/package 以下に作成されます。
 
 ### 作成可能なパッケージ一覧
 
-- raspbian-stretch_armv6
-- raspbian-stretch_armv7
+- raspbian-buster_armv6
+- raspbian-buster_armv7
 - ubuntu-18.04_armv8
 - ubuntu-18.04_x86_64
 - macos

--- a/patch/rpi-raspbian.conf
+++ b/patch/rpi-raspbian.conf
@@ -7,10 +7,10 @@ aptsources=Ports Rasp
 packages=libc6-dev libstdc++-6-dev libasound2-dev libpulse-dev libudev-dev libexpat1-dev libnss3-dev python-dev libgtk-3-dev
 source=http://ftp.jaist.ac.jp/raspbian
 keyring=raspbian-archive-keyring
-suite=stretch
+suite=buster
 
 [Rasp]
 packages=libraspberrypi-bin libraspberrypi-dev
 source=http://archive.raspberrypi.org/debian
 keyring=raspbian-archive-keyring
-suite=stretch
+suite=buster


### PR DESCRIPTION
stretch を buster に変更しただけです。

## 参考

- [Raspbian 2019\-06\-20 Release\-note 翻訳 \- Qiita](https://qiita.com/utaani/items/917854fd532bce8b0320)
- [Raspbian Buster リリース \- Qiita](https://qiita.com/nara256/items/ef03c163d6e77b147800)
- [Download Raspbian for Raspberry Pi](https://www.raspberrypi.org/downloads/raspbian/)

