### PR TITLE
ayame の client_id をオプション化する

### DIFF
--- a/doc/USE.md
+++ b/doc/USE.md
@@ -163,14 +163,15 @@ Options:
  ```
 $ ./momo ayame --help
 WebRTC Signaling Server Ayame
-Usage: ./momo ayame [OPTIONS] SIGNALING-URL ROOM-ID CLIENT-ID
- Positionals:
+Usage: ./momo ayame [OPTIONS] SIGNALING-URL ROOM-ID
+
+Positionals:
   SIGNALING-URL TEXT REQUIRED シグナリングホスト
-  ROOM-ID TEXT REQUIRED       ルーム ID
-  CLIENT-ID TEXT REQUIRED     クライアント ID
- Options:
-  -k,--key                    キー
+  ROOM-ID TEXT REQUIRED       ルームID
+
+Options:
   -h,--help                   Print this help message and exit
+  --client-id TEXT            クライアントID
 ```
 
 #### sora

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -369,12 +369,14 @@ void AyameWebsocketClient::onIceConnectionStateChange(webrtc::PeerConnectionInte
             new_state));
 }
 void AyameWebsocketClient::onIceCandidate(const std::string sdp_mid, const int sdp_mlineindex, const std::string sdp) {
+    // ayame では candidate sdp の交換で `ice` プロパティを用いる。 `candidate` ではないので注意
     json json_message = {
       {"type", "candidate"},
       {"ice", sdp}
     };
     ws_->sendText(json_message.dump());
 }
+
 void AyameWebsocketClient::onCreateDescription(webrtc::SdpType type, const std::string sdp) {
     json json_message = {
       {"type", "answer"},
@@ -382,6 +384,7 @@ void AyameWebsocketClient::onCreateDescription(webrtc::SdpType type, const std::
     };
     ws_->sendText(json_message.dump());
 }
+
 void AyameWebsocketClient::onSetDescription(webrtc::SdpType type) {
   RTC_LOG(LS_INFO) << __FUNCTION__ << " SdpType: " << webrtc::SdpTypeToString(type);
   if (type == webrtc::SdpType::kOffer) {

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -199,7 +199,6 @@ void AyameWebsocketClient::onConnect(boost::system::error_code ec) {
         reconnectAfter();
         return MOMO_BOOST_ERROR(ec, "connect");
     }
-
     // Websocket のハンドシェイク
     ws_->nativeSocket().async_handshake(parts_.host, parts_.path_query_fragment,
         boost::asio::bind_executor(
@@ -372,7 +371,7 @@ void AyameWebsocketClient::onIceConnectionStateChange(webrtc::PeerConnectionInte
 void AyameWebsocketClient::onIceCandidate(const std::string sdp_mid, const int sdp_mlineindex, const std::string sdp) {
     json json_message = {
       {"type", "candidate"},
-      {"candidate", sdp}
+      {"ice", sdp}
     };
     ws_->sendText(json_message.dump());
 }

--- a/src/connection_settings.h
+++ b/src/connection_settings.h
@@ -37,8 +37,8 @@ struct ConnectionSettings
   std::string p2p_document_root;
 
   std::string ayame_signaling_host;
-  std::string ayame_client_id;
   std::string ayame_room_id;
+  std::string ayame_client_id;
 
   int getWidth() {
     if (resolution == "QVGA") {
@@ -89,8 +89,8 @@ struct ConnectionSettings
     os << "priority: " << cs.priority << "\n";
     os << "port: " << cs.port << "\n";
     os << "ayame_signaling_host: " << cs.ayame_signaling_host << "\n";
-    os << "ayame_client_id: " << cs.ayame_client_id << "\n";
     os << "ayame_room_id: " << cs.ayame_room_id << "\n";
+    os << "ayame_client_id: " << cs.ayame_client_id << "\n";
     os << "sora_signaling_host: " << cs.sora_signaling_host << "\n";
     os << "sora_channel_id: " << cs.sora_channel_id << "\n";
     os << "sora_auto_connect: " << (cs.sora_auto_connect ? "true" : "false") << "\n";

--- a/src/rtc/manager.cpp
+++ b/src/rtc/manager.cpp
@@ -135,12 +135,12 @@ std::shared_ptr<RTCConnection> RTCManager::createConnection(
     return nullptr;
   }
 
-  std::string stream_id = Util::generateRundomChars();
+  std::string stream_id = Util::generateRandomChars();
 
   if (!_conn_settings.no_audio)
   {
     rtc::scoped_refptr<webrtc::AudioTrackInterface> audio_track(
-        _factory->CreateAudioTrack(Util::generateRundomChars(),
+        _factory->CreateAudioTrack(Util::generateRandomChars(),
                                    _factory->CreateAudioSource(cricket::AudioOptions())));
     if (audio_track)
     {
@@ -157,7 +157,7 @@ std::shared_ptr<RTCConnection> RTCManager::createConnection(
 
   if (_video_source) {
     rtc::scoped_refptr<webrtc::VideoTrackInterface> video_track(
-            _factory->CreateVideoTrack(Util::generateRundomChars(), _video_source));
+            _factory->CreateVideoTrack(Util::generateRandomChars(), _video_source));
     if (video_track)
     {
       if (_conn_settings.fixed_resolution) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -82,10 +82,12 @@ void Util::parseArgs(int argc, char *argv[], bool &is_daemon,
     }
   } else if (use_p2p) {
     local_nh.param<std::string>("document_root", cs.p2p_document_root, get_current_dir_name());
-  } else if (use_ayame && local_nh.hasParam("SIGNALING_URL") && local_nh.hasParam("ROOM_ID") && && local_nh.hasParam("CLIENT_ID")) {
+  } else if (use_ayame && local_nh.hasParam("SIGNALING_URL") && local_nh.hasParam("ROOM_ID")) {
     local_nh.getParam("SIGNALING_URL", cs.ayame_signaling_host);
     local_nh.getParam("ROOM_ID", cs.ayame_room_id);
-    local_nh.getParam("CLIENT_ID", cs.ayame_client_id);
+    // デフォルトはランダムな数値 17 桁
+    std::string default_ayame_client_id = generateRandomNumericChars(17);
+    local_nh.param<std::string>("client_id", cs.ayame_client_id, default_ayame_client_id);
   } else {
     exit(1);
   }
@@ -128,7 +130,9 @@ void Util::parseArgs(int argc, char *argv[], bool &is_daemon,
 
   ayame_app->add_option("SIGNALING-URL", cs.ayame_signaling_host, "シグナリングホスト")->required();
   ayame_app->add_option("ROOM-ID", cs.ayame_room_id, "ルームID")->required();
-  ayame_app->add_option("CLIENT-ID", cs.ayame_client_id, "クライアントID")->required();
+  // デフォルトはランダムな数値 17 桁
+  cs.ayame_client_id = generateRandomNumericChars(17);
+  ayame_app ->add_option("--client-id", cs.ayame_client_id, "クライアントID");
 
   sora_app->add_option("SIGNALING-URL", cs.sora_signaling_host, "シグナリングホスト")->required();
   sora_app->add_option("CHANNEL-ID", cs.sora_channel_id, "チャンネルID")->required();
@@ -211,16 +215,28 @@ void Util::parseArgs(int argc, char *argv[], bool &is_daemon,
 
 #endif
 
-std::string Util::generateRundomChars()
+std::string Util::generateRandomChars()
 {
-  return generateRundomChars(32);
+  return generateRandomChars(32);
 }
 
-std::string Util::generateRundomChars(size_t length)
+std::string Util::generateRandomChars(size_t length)
 {
   std::string result;
   rtc::CreateRandomString(length, &result);
   return result;
+}
+
+std::string Util::generateRandomNumericChars(size_t length) {
+    auto randomNumerics = []() -> char
+    {
+        const char charset[] = "0123456789";
+        const size_t max_index = (sizeof(charset) - 1);
+        return charset[ rand() % max_index ];
+    };
+    std::string result(length, 0);
+    std::generate_n(result.begin(), length, randomNumerics);
+    return result;
 }
 
 std::string Util::iceConnectionStateToString(

--- a/src/util.h
+++ b/src/util.h
@@ -13,8 +13,9 @@ class Util
     static void parseArgs(int argc, char *argv[], bool &is_daemon,
                           bool &use_p2p, bool &use_ayame, bool &use_sora,
                           int &log_level, ConnectionSettings &cs);
-    static std::string generateRundomChars();
-    static std::string generateRundomChars(size_t length);
+    static std::string generateRandomChars();
+    static std::string generateRandomChars(size_t length);
+    static std::string generateRandomNumericChars(size_t length);
     static std::string iceConnectionStateToString(
             webrtc::PeerConnectionInterface::IceConnectionState state) ;
 


### PR DESCRIPTION
```
$ ./momo ayame --help
WebRTC Signaling Server Ayame
Usage: ./momo ayame [OPTIONS] SIGNALING-URL ROOM-ID

Positionals:
  SIGNALING-URL TEXT REQUIRED シグナリングホスト
  ROOM-ID TEXT REQUIRED       ルームID

Options:
  -h,--help                   Print this help message and exit
  --client-id TEXT            クライアントID
```

`--client-id` を指定しない場合、 17 文字の numeric chars が自動で割り当てられます。

---
加えて `onIceCandidate` 時に投げるパラメータを `candidate` -> `ice` に修正しました。