### PR TITLE
macOS 版がビルドは成功するが動作させようとするとセグメンテーションフォルトする問題の修正

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -109,12 +109,12 @@ $(foreach package_name, $(PACKAGE_NAMES), $(eval $(call generateDockerRules,$(pa
 
 .PHONY: macos
 macos: macos.prepare
-	make -C .. MOMO_CFLAGS="-O2" PACKAGE_NAME=macos MOMO_VERSION=${MOMO_VERSION} momo
+	make -C .. MOMO_CFLAGS="-O2 -fobjc-arc" PACKAGE_NAME=macos MOMO_VERSION=${MOMO_VERSION} momo
 
 .PHONY: macos.package
 macos.package: macos.prepare
 	# momo を package モードでビルドし直す
-	rm -f ../_build/macos/momo && make -C .. MOMO_CFLAGS="-O2" PACKAGE_NAME=macos BUILD_MODE=package momo
+	rm -f ../_build/macos/momo && make -C .. MOMO_CFLAGS="-O2 -fobjc-arc" PACKAGE_NAME=macos BUILD_MODE=package momo
 
 	# パッケージのバイナリを作る
 	rm -rf package/momo-$(MOMO_VERSION)_macos

--- a/src/mac_helper/mac_capturer.h
+++ b/src/mac_helper/mac_capturer.h
@@ -15,10 +15,14 @@
 
 #include "api/media_stream_interface.h"
 #include "api/scoped_refptr.h"
+#include "base/RTCMacros.h"
 #include "modules/video_capture/video_capture.h"
 #include "rtc_base/thread.h"
 
 #include "rtc/scalable_track_source.h"
+
+RTC_FWD_DECL_OBJC_CLASS(RTCCameraVideoCapturer);
+RTC_FWD_DECL_OBJC_CLASS(RTCVideoSourceAdapter);
 
 class MacCapturer : public ScalableVideoTrackSource,
                     public rtc::VideoSinkInterface<webrtc::VideoFrame> {
@@ -38,8 +42,8 @@ class MacCapturer : public ScalableVideoTrackSource,
  private:
   void Destroy();
 
-  void* capturer_;
-  void* adapter_;
+  RTCCameraVideoCapturer* capturer_;
+  RTCVideoSourceAdapter* adapter_;
 };
 
 #endif  // TEST_MAC_CAPTURER_H_

--- a/src/mac_helper/mac_capturer.mm
+++ b/src/mac_helper/mac_capturer.mm
@@ -60,17 +60,15 @@ MacCapturer::MacCapturer(size_t width,
                          size_t height,
                          size_t target_fps,
                          size_t capture_device_index) {
-  RTCVideoSourceAdapter *adapter = [[RTCVideoSourceAdapter alloc] init];
-  adapter_ = (__bridge_retained void *)adapter;
-  adapter.capturer = this;
+  adapter_ = [[RTCVideoSourceAdapter alloc] init];
+  adapter_.capturer = this;
 
-  RTCCameraVideoCapturer *capturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:adapter];
-  capturer_ = (__bridge_retained void *)capturer;
+  capturer_ = [[RTCCameraVideoCapturer alloc] initWithDelegate:adapter_];
 
   AVCaptureDevice *device =
       [[RTCCameraVideoCapturer captureDevices] objectAtIndex:capture_device_index];
   AVCaptureDeviceFormat *format = SelectClosestFormat(device, width, height);
-  [capturer startCaptureWithDevice:device format:format fps:target_fps];
+  [capturer_ startCaptureWithDevice:device format:format fps:target_fps];
 }
 
 rtc::scoped_refptr<MacCapturer> MacCapturer::Create(size_t width,
@@ -81,12 +79,7 @@ rtc::scoped_refptr<MacCapturer> MacCapturer::Create(size_t width,
 }
 
 void MacCapturer::Destroy() {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
-  RTCVideoSourceAdapter *adapter = (__bridge_transfer RTCVideoSourceAdapter *)adapter_;
-  RTCCameraVideoCapturer *capturer = (__bridge_transfer RTCCameraVideoCapturer *)capturer_;
-  [capturer stopCapture];
-#pragma clang diagnostic pop
+  [capturer_ stopCapture];
 }
 
 MacCapturer::~MacCapturer() {

--- a/src/rtc/scalable_track_source.cpp
+++ b/src/rtc/scalable_track_source.cpp
@@ -56,7 +56,7 @@ void ScalableVideoTrackSource::OnCapturedFrame(const webrtc::VideoFrame& frame) 
     return;
   }
 
-  if (frame.video_frame_buffer()->type() == webrtc::VideoFrameBuffer::Type::kNative)
+  if (useNativeBuffer() && frame.video_frame_buffer()->type() == webrtc::VideoFrameBuffer::Type::kNative)
   {
     NativeBuffer* frame_buffer = dynamic_cast<NativeBuffer*>(frame.video_frame_buffer().get());
     frame_buffer->SetScaledSize(adapted_width, adapted_height);

--- a/src/rtc/scalable_track_source.h
+++ b/src/rtc/scalable_track_source.h
@@ -28,6 +28,7 @@ class ScalableVideoTrackSource : public rtc::AdaptedVideoTrackSource {
   webrtc::MediaSourceInterface::SourceState state() const override;
   bool remote() const override;
   void OnCapturedFrame(const webrtc::VideoFrame& frame);
+  bool useNativeBuffer() { return false; }
 
  private:
   rtc::TimestampAligner timestamp_aligner_;

--- a/src/v4l2_video_capturer/v4l2_video_capturer.cpp
+++ b/src/v4l2_video_capturer/v4l2_video_capturer.cpp
@@ -318,6 +318,12 @@ int32_t V4L2VideoCapture::StopCapture() {
   return 0;
 }
 
+bool V4L2VideoCapture::useNativeBuffer() {
+  return _useNative &&
+          (_captureVideoType == webrtc::VideoType::kMJPEG ||
+           _captureVideoType == webrtc::VideoType::kI420);
+}
+
 // critical section protected by the caller
 
 bool V4L2VideoCapture::AllocateVideoBuffers() {
@@ -439,9 +445,7 @@ bool V4L2VideoCapture::CaptureProcess() {
       }
 
       rtc::scoped_refptr<webrtc::VideoFrameBuffer> dst_buffer = nullptr;
-      if (_useNative &&
-          (_captureVideoType == webrtc::VideoType::kMJPEG ||
-           _captureVideoType == webrtc::VideoType::kI420))
+      if (useNativeBuffer())
       {
         rtc::scoped_refptr<NativeBuffer> native_buffer(
             NativeBuffer::Create(

--- a/src/v4l2_video_capturer/v4l2_video_capturer.h
+++ b/src/v4l2_video_capturer/v4l2_video_capturer.h
@@ -35,6 +35,8 @@ class V4L2VideoCapture : public ScalableVideoTrackSource {
   int32_t Init(const char* deviceUniqueId);
   int32_t StartCapture(ConnectionSettings cs);
 
+  bool useNativeBuffer() override;
+
  private:
   enum { kNoOfV4L2Bufffers = 4 };
 


### PR DESCRIPTION
#89 で未解決となっている問題の1つを修正する PR です。

MacCapturer を利用する場合、
frame.video_frame_buffer()->type() == webrtc::VideoFrameBuffer::Type::kNative
を返しますが、内部では NativeBuffer を使っていないので、`dynamic_cast` が失敗し、`nullptr` を返します。これによって `Segmentation fault: 11`  (EXC_BAD_ACCESS (code=1, address=0x10) 要するに NullPointer 例外) が発生しています。

V4L2VideoCapture を使う場合でも、captureVideoType が
webrtc::VideoType::kMJPEG か webrtc::VideoType::kI420 ではないケースで
同様の問題が発生する可能性があるため、ScalableTrackSource#useNativeBuffer() を
追加して、dynamic_cast 前に条件チェックをするようにしました。

単純に、`dynamic_cast` の戻り値が `nullptr` であるかをチェックするでも動くのですが、こちらの方がコード的に意味が通るかと思い、そうしました。

ARC 対応はおまけです。
残念ながら、この PR では #77 は修正できていません。