### PR TITLE
macOS 版 Momo で VideoToolbox 利用時の解像度変更時に落ちる問題の修正

### DIFF
--- a/build/macos/Makefile
+++ b/build/macos/Makefile
@@ -37,6 +37,7 @@ $(LIBWEBRTC): check
 	prepare_webrtc_macos "" $(WEBRTC_COMMIT) $(CURDIR)/webrtc && \
 	cd $(CURDIR)/webrtc/src && \
 	patch -p2 < $(CURDIR)/../../patch/4k.patch && \
+	patch -p2 < $(CURDIR)/../../patch/macos_h264_encoder.patch && \
 	gn gen $(CURDIR)/webrtc-build/macos --args='target_os="mac" is_debug=false rtc_include_tests=false rtc_build_examples=false rtc_use_h264=false is_component_build=false use_rtti=true libcxx_abi_unstable=false' && \
 	ninja -C $(CURDIR)/webrtc-build/macos && \
 	ninja -C $(CURDIR)/webrtc-build/macos \

--- a/patch/macos_h264_encoder.patch
+++ b/patch/macos_h264_encoder.patch
@@ -1,0 +1,12 @@
+diff --git a/src/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm b/src/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+index 4028e7acee..585743e1aa 100644
+--- a/src/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
++++ b/src/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+@@ -554,6 +554,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264::ProfileLevelId &profile_level_id
+   OSType framePixelFormat = [self pixelFormatOfFrame:frame];
+ 
+   if (_compressionSession) {
++    _pixelBufferPool = VTCompressionSessionGetPixelBufferPool(_compressionSession);
+     // The pool attribute `kCVPixelBufferPixelFormatTypeKey` can contain either an array of pixel
+     // formats or a single pixel format.
+     NSDictionary *poolAttributes =


### PR DESCRIPTION
#77 の修正。

libWebRTC側のデグレなので、暫定的にパッチをあてて対応します。

デバッガで確認したところ、以下のリンク先と同じ問題にヒットしている模様。現状、libWebRTC に patch をあてて対応するしかなさそう。（正確にはカスタムな RTCEncoderFactory を書くという手もあるもがメンテコストが大変なので、個人的に却下しました）長期的には libWebRTC 側で直してもらいたいところ。

https://groups.google.com/forum/#!topic/discuss-webrtc/AVeyMXnM0gY

ここの変更で入った問題のようです。ちゃんと追えてませんが、1年前だから、m73 あたりで入ったのではないかと。

https://webrtc-review.googlesource.com/c/src/+/90403/7/sdk/objc/Framework/Classes/VideoToolbox/RTCVideoEncoderH264.mm

## 参考

`-g` オプションをつけてコンパイルした `momo` を lldb 経由で起動して落ちた時のログ。落ちている場所が、上記の URL の問題と同じ箇所なので、そこに書いてある修正を、処理の効率を考えて、少し場所は変えて適用しています。

```
Process 24697 stopped
* thread #2, queue = 'EncoderQueue', stop reason = EXC_BAD_ACCESS (code=1, address=0x10ce76100)
    frame #0: 0x00007fff5711d3a9 libobjc.A.dylib`objc_msgSend + 41
libobjc.A.dylib`objc_msgSend:
->  0x7fff5711d3a9 <+41>: cmpq   (%r11), %rsi
    0x7fff5711d3ac <+44>: jne    0x7fff5711d3b2            ; <+50>
    0x7fff5711d3ae <+46>: jmpq   *0x8(%r11)
    0x7fff5711d3b2 <+50>: cmpq   $0x1, (%r11)
Target 0: (momo) stopped.
(lldb) bt
* thread #2, queue = 'EncoderQueue', stop reason = EXC_BAD_ACCESS (code=1, address=0x10ce76100)
  * frame #0: 0x00007fff5711d3a9 libobjc.A.dylib`objc_msgSend + 41
    frame #1: 0x00007fff2e689196 CoreVideo`_getCVPixelBufferPool(__CVPixelBufferPool*) + 20
    frame #2: 0x00007fff2e68dcc7 CoreVideo`CVPixelBufferPoolGetPixelBufferAttributes + 9
    frame #3: 0x00000001009b86cc momo`::-[RTCVideoEncoderH264 resetCompressionSessionIfNeededWithFrame:](self=0x0000000102640c00, _cmd=<unavailable>, frame=<unavailable>) at RTCVideoEncoderH264.mm:560:34 [opt]
    frame #4: 0x00000001009b77dd momo`::-[RTCVideoEncoderH264 encode:codecSpecificInfo:frameTypes:](self=0x0000000102640c00, _cmd=<unavailable>, frame=<unavailable>, codecSpecificInfo=<unavailable>, frameTypes=<unavailable>) at RTCVideoEncoderH264.mm:402:7 [opt]
    frame #5: 0x00000001009b19e4 momo`webrtc::(anonymous namespace)::ObjCVideoEncoder::Encode(this=0x000000010244a880, frame=0x00007000033d64b8, frame_types=<unavailable>) at objc_video_encoder_factory.mm:83:12 [opt]
    frame #6: 0x00000001004322dd momo`webrtc::VideoStreamEncoder::EncodeVideoFrame(this=0x000000010308f800, video_frame=<unavailable>, time_when_posted_us=4331993600) at video_stream_encoder.cc:1340:43 [opt]
    frame #7: 0x0000000100431837 momo`webrtc::VideoStreamEncoder::MaybeEncodeVideoFrame(this=<unavailable>, video_frame=0x000000010244b0f0, time_when_posted_us=6612180852) at video_stream_encoder.cc:1206:3 [opt]
    frame #8: 0x00000001004360e7 momo`webrtc::webrtc_new_closure_impl::ClosureTask<webrtc::VideoStreamEncoder::OnFrame(webrtc::VideoFrame const&)::$_8>::Run() [inlined] webrtc::VideoStreamEncoder::OnFrame(this=0x000000010244b0e8)::$_8::operator()() const at video_stream_encoder.cc:941:11 [opt]
    frame #9: 0x0000000100436098 momo`webrtc::webrtc_new_closure_impl::ClosureTask<webrtc::VideoStreamEncoder::OnFrame(webrtc::VideoFrame const&)::$_8>::Run(this=0x000000010244b0e0) at to_queued_task.h:32 [opt]
    frame #10: 0x00000001004e6375 momo`webrtc::(anonymous namespace)::TaskQueueGcd::RunTask(task_context=0x000000010245f530) at task_queue_gcd.cc:120:13 [opt]
    frame #11: 0x00007fff588a363d libdispatch.dylib`_dispatch_client_callout + 8
    frame #12: 0x00007fff588a98e0 libdispatch.dylib`_dispatch_lane_serial_drain + 602
    frame #13: 0x00007fff588aa396 libdispatch.dylib`_dispatch_lane_invoke + 385
    frame #14: 0x00007fff588b26ed libdispatch.dylib`_dispatch_workloop_worker_thread + 598
    frame #15: 0x00007fff58ae3611 libsystem_pthread.dylib`_pthread_wqthread + 421
    frame #16: 0x00007fff58ae33fd libsystem_pthread.dylib`start_wqthread + 13
```