### PR TITLE
Raspberry Pi 用にビデオデバイスを選択する機能を実装した

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 ## develop
 
+## 19.08.1
+
+- [ADD] Raspberry Pi 用に `--video-device` オプションを追加
+    - @melpon
+
 ## 19.08.0
 
 - [UPDATE] nlohmann/json を v3.7.0 にアップデートする

--- a/doc/USE_RASPBERRY_PI.md
+++ b/doc/USE_RASPBERRY_PI.md
@@ -71,11 +71,20 @@ USBカメラでは逆にフレームレートが落ちるため使わないで�
 $ ./momo --force-i420 --no-audio --port 8080 test
 ```
 
+### --video-device
+
+`--video-device` は Raspberry Pi でビデオデバイス（つまりカメラ）を指定する機能です。 1 台の Raspberry Pi で複数の Momo を起動し、ビデオデバイスが複数あり、それぞれここに割り当てたい時に利用できます。
+
+
+```shell
+$ ./momo --video-device /dev/video0 test
+```
+
 ## Raspberry Pi 専用カメラでパフォーマンスが出ない
 
 [Raspbian で Raspberry Pi の Raspberry Pi 用カメラを利用する場合](#raspbian-で-raspberry-pi-の-raspberry-pi-用カメラを利用する場合)通りに設定されているか確認してください。特に `max_video_width=2592 max_video_height=1944` が記載されていなければ高解像度時にフレームレートが出ません。
 
-Raspberry Pi 専用カメラ利用時には `--use-native --force-i420` オプションを併用するとCPU使用率が下がりフレームレートが上がります。例えば、 RaspberryPi Zero の場合には
+Raspberry Pi 専用カメラ利用時には `--use-native --force-i420` オプションを併用するとCPU使用率が下がりフレームレートが上がります。例えば、 Raspberry Pi Zero の場合には
 
 ```shell
 $ ./momo --resolution=HD --framerate=20 --force-i420 --use-native test
@@ -94,5 +103,3 @@ avoid_warnings=2
 ```
 
 この設定であれば HD は 30fps, FHD では 15fps 程度の性能を発揮します。
-
-

--- a/src/connection_settings.h
+++ b/src/connection_settings.h
@@ -21,6 +21,7 @@ struct ConnectionSettings
   bool no_audio = false;
   bool force_i420 = false;
   bool use_native = false;
+  std::string video_device = "";
   std::string video_codec = "VP8";
   std::string audio_codec = "OPUS";
   int video_bitrate = 0;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -113,6 +113,7 @@ void Util::parseArgs(int argc, char *argv[], bool &is_daemon,
 #if USE_MMAL_ENCODER
   app.add_flag("--force-i420", cs.force_i420, "強制的にI420にする");
   app.add_flag("--use-native", cs.use_native, "MJPEGのデコードとビデオのリサイズをハードウェアで行う");
+  app.add_option("--video-device", cs.video_device, "デバイスファイル名。省略時はどれかのビデオデバイスを自動検出")->check(CLI::ExistingFile);
 #endif
   app.add_set("--resolution", cs.resolution, {"QVGA", "VGA", "HD", "FHD", "4K"},
               "解像度");

--- a/src/v4l2_video_capturer/v4l2_video_capturer.h
+++ b/src/v4l2_video_capturer/v4l2_video_capturer.h
@@ -32,12 +32,14 @@ class V4L2VideoCapture : public ScalableVideoTrackSource {
       size_t capture_device_index);
   V4L2VideoCapture();
   ~V4L2VideoCapture();
-  int32_t Init(const char* deviceUniqueId);
+  int32_t Init(const char* deviceUniqueId, const std::string& specifiedVideoDevice);
   int32_t StartCapture(ConnectionSettings cs);
 
   bool useNativeBuffer() override;
 
  private:
+  bool FindDevice(const char* deviceUniqueIdUTF8, const std::string& device);
+
   enum { kNoOfV4L2Bufffers = 4 };
 
   int32_t StopCapture();
@@ -50,7 +52,7 @@ class V4L2VideoCapture : public ScalableVideoTrackSource {
   std::unique_ptr<rtc::PlatformThread> _captureThread;
   rtc::CriticalSection _captureCritSect;
   bool quit_ RTC_GUARDED_BY(_captureCritSect);
-  int32_t _deviceId;
+  std::string _videoDevice;
   int32_t _deviceFd;
 
   int32_t _buffersAllocatedByDevice;


### PR DESCRIPTION
`./momo --video-device /dev/video0 ...` の様にデバイスファイルを指定することでビデオデバイスを選択できるようにしました。

```
$ ./momo --help
Momo - WebRTC ネイティブクライアント
Usage: ./momo [OPTIONS] [SUBCOMMAND]

Options:
  -h,--help                   Print this help message and exit
  --no-video                  ビデオを表示しない
  --no-audio                  オーディオを出さない
  --force-i420                強制的にI420にする
  --use-native                MJPEGのデコードとビデオのリサイズをハードウェアで行う
  --video-device TEXT:FILE    デバイスファイル名。省略時はどれかのビデオデバイスを自動検出
  --resolution TEXT:{4K,FHD,HD,QVGA,VGA}
                              解像度
  --framerate INT:INT in [1 - 60]
                              フレームレート
  --fixed-resolution          固定解像度
  --priority TEXT:{BALANCE,FRAMERATE,RESOLUTION}
                              優先設定 (Experimental)
  --port INT:INT in [0 - 65535]
                              ポート番号(デフォルト:8080)
  --daemon                    デーモン化する
  --version                   バージョン情報の表示
  --log-level INT:value in {verbose->0,info->1,warning->2,error->3,none->4} OR {0,1,2,3,4}
                              ログレベル

Subcommands:
  test                        開発向け
  ayame                       WebRTC Signaling Server Ayame
  sora                        WebRTC SFU Sora
```
