### PR TITLE
オーディオフラグの無効化オプションを追加した

### DIFF
--- a/src/connection_settings.h
+++ b/src/connection_settings.h
@@ -44,6 +44,12 @@ struct ConnectionSettings
   std::string ayame_client_id;
   std::string ayame_signaling_key = "";
 
+  bool disable_echo_cancellation = false;
+  bool disable_auto_gain_control = false;
+  bool disable_noise_suppression = false;
+  bool disable_highpass_filter = false;
+  bool disable_typing_detection = false;
+
   int getWidth() {
     if (resolution == "QVGA") {
       return 480;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -70,6 +70,21 @@ void Util::parseArgs(int argc, char *argv[], bool &is_daemon,
   local_nh.param<int>("port", cs.port, cs.port);
   local_nh.param<int>("log_level", log_level, log_level);
 
+  // オーディオフラグ
+  local_nh.param<bool>("disable_echo_cancellation",
+                       cs.disable_echo_cancellation,
+                       cs.disable_echo_cancellation);
+  local_nh.param<bool>("disable_auto_gain_control",
+                       cs.disable_auto_gain_control,
+                       cs.disable_auto_gain_control);
+  local_nh.param<bool>("disable_noise_suppression",
+                       cs.disable_noise_suppression,
+                       cs.disable_noise_suppression);
+  local_nh.param<bool>("disable_highpass_filter", cs.disable_highpass_filter,
+                       cs.disable_highpass_filter);
+  local_nh.param<bool>("disable_typing_detection", cs.disable_typing_detection,
+                       cs.disable_typing_detection);
+
   if (use_sora && local_nh.hasParam("SIGNALING_URL") && local_nh.hasParam("CHANNEL_ID")) {
     local_nh.getParam("SIGNALING_URL", cs.sora_signaling_host);
     local_nh.getParam("CHANNEL_ID", cs.sora_channel_id);
@@ -128,6 +143,18 @@ void Util::parseArgs(int argc, char *argv[], bool &is_daemon,
       {{"verbose", 0}, {"info", 1}, {"warning", 2}, {"error", 3}, {"none", 4}});
   app.add_option("--log-level", log_level, "ログレベル")
       ->transform(CLI::CheckedTransformer(log_level_map, CLI::ignore_case));
+
+  // オーディオフラグ
+  app.add_flag("--disable-echo-cancellation", cs.disable_echo_cancellation,
+               "エコーキャンセルを無効");
+  app.add_flag("--disable-auto-gain-control", cs.disable_auto_gain_control,
+               "オートゲインコントロール無効");
+  app.add_flag("--disable-noise-suppression", cs.disable_noise_suppression,
+               "ノイズサプレッション無効");
+  app.add_flag("--disable-highpass-filter", cs.disable_highpass_filter,
+               "ハイパスフィルター無効");
+  app.add_flag("--disable-typing-detection", cs.disable_typing_detection,
+               "タイピングディテクション無効");
 
   auto test_app = app.add_subcommand("test", "開発向け");
   auto ayame_app = app.add_subcommand("ayame", "WebRTC Signaling Server Ayame");


### PR DESCRIPTION
追加しました。

```
$ ./momo --help
Momo - WebRTC ネイティブクライアント
Usage: ./momo [OPTIONS] [SUBCOMMAND]

Options:
  -h,--help                   Print this help message and exit
  --no-video                  ビデオを表示しない
  --no-audio                  オーディオを出さない
  --resolution TEXT:{4K,FHD,HD,QVGA,VGA}
                              解像度
  --framerate INT:INT in [1 - 60]
                              フレームレート
  --fixed-resolution          固定解像度
  --priority TEXT:{BALANCE,FRAMERATE,RESOLUTION}
                              優先設定 (Experimental)
  --port INT:INT in [0 - 65535]
                              ポート番号(デフォルト:8080)
  --daemon                    デーモン化する
  --version                   バージョン情報の表示
  --log-level INT:value in {verbose->0,info->1,warning->2,error->3,none->4} OR {0,1,2,3,4}
                              ログレベル
  --disable-echo-cancellation エコーキャンセルを無効
  --disable-auto-gain-control オートゲインコントロール無効
  --disable-noise-suppression ノイズサプレッション無効
  --disable-highpass-filter   ハイパスフィルター無効
  --disable-typing-detection  タイピングディテクション無効

Subcommands:
  test                        開発向け
  ayame                       WebRTC Signaling Server Ayame
  sora                        WebRTC SFU Sora
```

注意点としては、`--disable-*` のフラグを指定しなかった場合は、有効になるのではなく、デフォルトの設定が使われます。現在のデフォルトは全て有効になっているので実質同じ意味です。

ただ、今後どこかでデフォルトが無効になった場合、フラグを指定してもしてなくても無効になり、有効化する方法が無くなります。
その場合はフラグを `--enable-*` に直して修正すればいいかなと思っています。