### PR TITLE
GitHub Actions 対応

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build workflow
+on:
+  push:
+    # 現状 GitHub Actions には [ci skip] 相当の機能がないので、ドキュメント関連は最初からビルド監視対象から除いておく
+    # ただし、再帰的に全ファイルにマッチするワイルドカード表現が書けないので、全ファイルを監視対象にするには、
+    # 監視が必要なディレクトリ階層分だけ指定しないといけない
+    # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requestpaths 
+    paths:
+      - '*'
+      - '*/*'
+      - '*/*/*'
+      - '!*.md'
+      - '!doc/*'
+      - '!html/*'
+      - '!.github/ISSUE_TEMPLATE/*'
+      - '!.circleci/*'
+
+jobs:
+  build_raspbian-buster_armv6:
+    name: Build momo for raspbian-buster_armv6
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv6
+        working-directory: build
+        timeout-minutes: 120
+  build_raspbian-buster_armv7:
+    name: Build momo for raspbian-buster_armv7
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv7
+        working-directory: build
+        timeout-minutes: 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,5 @@
 name: Build workflow
-on:
-  push:
-    # 現状 GitHub Actions には [ci skip] 相当の機能がないので、ドキュメント関連は最初からビルド監視対象から除いておく
-    # ただし、再帰的に全ファイルにマッチするワイルドカード表現が書けないので、全ファイルを監視対象にするには、
-    # 監視が必要なディレクトリ階層分だけ指定しないといけない
-    # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requestpaths 
-    paths:
-      - '*'
-      - '*/*'
-      - '*/*/*'
-      - '!*.md'
-      - '!doc/*'
-      - '!html/*'
-      - '!.github/ISSUE_TEMPLATE/*'
-      - '!.circleci/*'
+on: push
 
 jobs:
   build_raspbian-buster_armv6:

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -1,0 +1,33 @@
+name: Daily build workflow
+on:
+  schedule:
+    # UTCで記述する事、この場合は日本時間 9 時にしたいので -9 して 0 にしてある
+    - cron: "0 0 * * *"
+    # 明示的な branch の指定はできず、デフォルト branch の latest commit に対して実行される
+    # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onschedule
+
+jobs:
+  build_ubuntu-18_04_armv8:
+    name: Build momo for build_ubuntu-18.04_armv8
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_armv8
+        working-directory: build
+        timeout-minutes: 120
+  build_ubuntu-18_04_x86_64:
+    name: Build momo for build_ubuntu-18.04_x86_64
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
+        working-directory: build
+        timeout-minutes: 120
+  build_macos:
+    name: Build momo for macOS 10.14
+    runs-on: macos-10.14
+    steps:
+      - uses: actions/checkout@v1
+      - run: make macos
+        working-directory: build
+        timeout-minutes: 120


### PR DESCRIPTION
- [x] push ごとの build
  - build_raspbian-buster_armv6
  - build_raspbian-buster_armv7
- [x] Daily Build
  - build_ubuntu-18_04_armv8
  - build_ubuntu-18_04_x86_64
  - macOS 10.14

## 基本方針

- 現状の CircleCI の設定をそのまま持ってくる
- この PR では CircleCI の設定は削除しない

## 検討事項

- macOS は CircleCI の macOS のリソースが限られているため、Weekly ビルドになっていたが、GitHub Actions の場合は制限がないので、Daily Build に移動しました。特に異論はないと思いますが、必要なら Weekly ビルドに戻すことも可能です。
- GitHub Actions はリポジトリごとに最大 20 並列まで実行できるので、全ての OS のビルドを `push` 時に走らせてもリソース的には問題ないです。やりますか？それとも、現状の Push ごとのビルド (Raspbian のみ + Daily ビルド (Ubuntu + macOS) の構成を維持しますか？
- 現状 GitHub Actions には [ci skip] 相当の機能がないので、`build.yml` では[ドキュメント関連は最初からビルド監視対象から除いてある](https://github.com/shiguredo/momo/pull/98/files#diff-898e737ee4e56ba042bda31764bed49e)。ただし、再帰的に全ファイルにマッチするワイルドカード表現 (.gitignore などで書ける `**/*` 的なやつ)が書けないので、全ファイルを監視対象にするには、監視が必要なディレクトリ階層分だけ指定しないといけない。これはディレクトリ構成が変わった時にメンテナンスが大変なので、現時点で実装しておくべきなのかは要相談。必要なければ消します。

  - ドキュメント: https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requestpaths 

## 移植できなかったこと

- Docker Layer Cache はサポートしていないので、移植できない。ただし、libwebrtc のビルド時間が支配的なので、実際のビルド時間にほぼ差はない。というか、むしろ少し早い
  - [直近の build_raspbian-buster_armv6 の CircleCI build](https://circleci.com/gh/shiguredo/momo/508) => 1h23m
  - [GitHub Actions での build_raspbian-buster_armv6 の build](https://github.com/hakobera/momo/runs/218979312) => 1h11m