### PR TITLE
[WIP] GitHub Actions が "No space left on device" で失敗する問題を修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: NOTTY=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120
@@ -15,6 +16,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: NOTTY=1 make raspbian-buster_armv7
         working-directory: build
         timeout-minutes: 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: docker volume rm $(docker volume ls -qf dangling=true)
       - run: NOTTY=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120
@@ -15,6 +16,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: docker volume rm $(docker volume ls -qf dangling=true)
       - run: NOTTY=1 make raspbian-buster_armv7
         working-directory: build
         timeout-minutes: 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-      - run: ulimit -n
-      - run: sudo sh -c "ulimit -n 65535 && exec su $LOGNAME"
-      - run: ulimit -n
-      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv6
+      - run: NOTTY=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120
   build_raspbian-buster_armv7:
@@ -19,25 +15,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-      - run: ulimit -n
-      - run: sudo sh -c "ulimit -n 65535 && exec su $LOGNAME"
-      - run: ulimit -n
-      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv7
+      - run: NOTTY=1 make raspbian-buster_armv7
         working-directory: build
         timeout-minutes: 120
   
-  # エラーが修正されたかどうかを確認するために暫定的に追加
-  build_ubuntu-18_04_x86_64:
-    name: Build momo for build_ubuntu-18.04_x86_64
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v1
-      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-      - run: ulimit -n
-      - run: sudo sh -c "ulimit -n 65535 && exec su $LOGNAME"
-      - run: ulimit -n
-      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
-        working-directory: build
-        timeout-minutes: 120
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - run: ulimit -n
+      - run: ulimit -n 65535
+      - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120
@@ -17,6 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - run: ulimit -n
+      - run: ulimit -n 65535
+      - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv7
         working-directory: build
         timeout-minutes: 120
@@ -28,6 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - run: ulimit -n
+      - run: ulimit -n 65535
+      - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
         working-directory: build
         timeout-minutes: 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-      - run: cat /proc/sys/fs/inotify/max_user_watches
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120
@@ -17,6 +16,19 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv7
         working-directory: build
         timeout-minutes: 120
+  
+  # エラーが修正されたかどうかを確認するために暫定的に追加
+  build_ubuntu-18_04_x86_64:
+    name: Build momo for build_ubuntu-18.04_x86_64
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
+        working-directory: build
+        timeout-minutes: 120
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - run: docker volume rm $(docker volume ls -qf dangling=true)
       - run: NOTTY=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120
@@ -16,7 +15,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - run: docker volume rm $(docker volume ls -qf dangling=true)
       - run: NOTTY=1 make raspbian-buster_armv7
         working-directory: build
         timeout-minutes: 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: ulimit -n
-      - run: ulimit -n 65535
+      - run: sudo ulimit -n 65535
       - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv7
         working-directory: build
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: ulimit -n
-      - run: ulimit -n 65535
+      - run: sudo ulimit -n 65535
       - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - run: cat /proc/sys/fs/inotify/max_user_watches
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: ulimit -n
-      - run: ulimit -n 65535
+      - run: sudo sh -c "ulimit -n 65535 && exec su $LOGNAME"
       - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv6
         working-directory: build
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: ulimit -n
-      - run: sudo ulimit -n 65535
+      - run: sudo sh -c "ulimit -n 65535 && exec su $LOGNAME"
       - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv7
         working-directory: build
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: ulimit -n
-      - run: sudo ulimit -n 65535
+      - run: sudo sh -c "ulimit -n 65535 && exec su $LOGNAME"
       - run: ulimit -n
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
         working-directory: build

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_armv8
         working-directory: build
         timeout-minutes: 120
@@ -20,6 +21,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_armv8_jetson_nano
         working-directory: build
         timeout-minutes: 120
@@ -28,6 +30,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
         working-directory: build
         timeout-minutes: 120

--- a/script/docker_run.sh
+++ b/script/docker_run.sh
@@ -90,10 +90,10 @@ if [ "$MOUNT_TYPE" = "mount" ]; then
   # マウントする場合は、単純にマウントしてビルドするだけ
   if [ "$BUILD_MODE" = "build" ]; then
     # build
-    docker run -it --rm --ulimit nofile=65535 -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo &&                                          make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME MOMO_VERSION=$MOMO_VERSION                    momo"
+    docker run -it --rm -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo &&                                          make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME MOMO_VERSION=$MOMO_VERSION                    momo"
   else
     # package
-    docker run -it --rm --ulimit nofile=65535 -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo && make PACKAGE_NAME=$PACKAGE_NAME clean && make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME BUILD_MODE=package MOMO_VERSION=$MOMO_VERSION momo"
+    docker run -it --rm -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo && make PACKAGE_NAME=$PACKAGE_NAME clean && make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME BUILD_MODE=package MOMO_VERSION=$MOMO_VERSION momo"
   fi
 else
   # マウントしない場合は、コンテナを起動して、コンテナに必要なファイルを転送して、コンテナ上でビルドして、生成されたファイルをコンテナから戻して、コンテナを終了する

--- a/script/docker_run.sh
+++ b/script/docker_run.sh
@@ -90,10 +90,10 @@ if [ "$MOUNT_TYPE" = "mount" ]; then
   # マウントする場合は、単純にマウントしてビルドするだけ
   if [ "$BUILD_MODE" = "build" ]; then
     # build
-    docker run -it --rm -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo &&                                          make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME MOMO_VERSION=$MOMO_VERSION                    momo"
+    docker run -it --rm --ulimit nofile=65535 -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo &&                                          make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME MOMO_VERSION=$MOMO_VERSION                    momo"
   else
     # package
-    docker run -it --rm -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo && make PACKAGE_NAME=$PACKAGE_NAME clean && make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME BUILD_MODE=package MOMO_VERSION=$MOMO_VERSION momo"
+    docker run -it --rm --ulimit nofile=65535 -v "$WORK_DIR/..:/root/momo" "$DOCKER_IMAGE" /bin/bash -c "cd /root/momo && make PACKAGE_NAME=$PACKAGE_NAME clean && make MOMO_CFLAGS='-O2' PACKAGE_NAME=$PACKAGE_NAME BUILD_MODE=package MOMO_VERSION=$MOMO_VERSION momo"
   fi
 else
   # マウントしない場合は、コンテナを起動して、コンテナに必要なファイルを転送して、コンテナ上でビルドして、生成されたファイルをコンテナから戻して、コンテナを終了する


### PR DESCRIPTION
<del>実際にディスク容量が足りないのではなく、`fs.inotify.max_user_watches` が上限に達するとこのエラーがでるようです。なので、make の実行前にこれを増やすことで対応します。</del> 関係ありませんでした。

<del>参考: https://medium.com/@jonnyburger/first-look-using-github-actions-for-building-ios-and-android-apps-4749609b96f0</del>