### PR TITLE
GitHub Actions でディスク容量が足りない問題の修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,20 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: df -hT
+      - run: .github/workflows/script/disk_cleanup.sh
+      - run: df -hT
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv6
         working-directory: build
         timeout-minutes: 120
+      - run: df -hT
+      - run: docker system df -v
   build_raspbian-buster_armv7:
     name: Build momo for raspbian-buster_armv7
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: .github/workflows/script/disk_cleanup.sh
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make raspbian-buster_armv7
         working-directory: build
         timeout-minutes: 120

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: .github/workflows/script/disk_cleanup.sh
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_armv8
         working-directory: build
         timeout-minutes: 120
@@ -20,6 +21,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: .github/workflows/script/disk_cleanup.sh
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_armv8_jetson_nano
         working-directory: build
         timeout-minutes: 120
@@ -28,6 +30,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: .github/workflows/script/disk_cleanup.sh
       - run: DOCKER_BUILDKIT=1 NOTTY=1 NOMOUNT=1 make ubuntu-18.04_x86_64
         working-directory: build
         timeout-minutes: 120

--- a/.github/workflows/script/disk_cleanup.sh
+++ b/.github/workflows/script/disk_cleanup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Cache 済み Docker Image の削除
+docker rmi $(docker images -q -a)
+
+# Android SDK の削除
+sudo rm -rf ${ANDROID_HOME}
+
+# JVM の削除
+sudo rm -rf ${JAVA_HOME_11_X64}
+sudo rm -rf ${JAVA_HOME_12_X64}
+sudo rm -rf ${JAVA_HOME_8_X64}
+sudo rm -rf ${JAVA_HOME_7_X64}


### PR DESCRIPTION
GitHub Actions の VM では 30GB 程度の空き容量があるが、Docker を使ったビルドではその容量を使い切ってしまうため、例えば、[このビルド](https://github.com/shiguredo/momo/commit/86ae81e42db7566ca4477e123dda939ce67c9ede/checks?check_suite_id=252398534) のように `No spece left on device` でエラーになる。

ディスク容量を自体拡張することはできないため、[GitHub Actions の仮想環境でのソフトウェア](https://help.github.com/ja/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts) に記載のプリインストールされているものの中から、momo のビルドに不要なものを削除することで対応する。全て削除するのは現実的ではないので、大きめの容量を取っている以下をピックアップして削除するようにした。

* Docker イメージキャッシュ（約3GB）
* Android SDK（約7GB）
* JVM（約1.5GB）

一旦、ビルドは通るようになったが、2019/9月の終わり頃から失敗するようになった理由は不明なので、この修正はとりあえずのワークラウンドでしかない。根本原因は要確認。webrtc の head になにか大きなファイルがコミットされたりしたのだろうか？