### PR TITLE
macOS で --video-device を指定可能にする

### DIFF
--- a/src/mac_helper/mac_capturer.h
+++ b/src/mac_helper/mac_capturer.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "api/media_stream_interface.h"
 #include "api/scoped_refptr.h"
@@ -21,6 +22,7 @@
 
 #include "rtc/scalable_track_source.h"
 
+RTC_FWD_DECL_OBJC_CLASS(AVCaptureDevice);
 RTC_FWD_DECL_OBJC_CLASS(RTCCameraVideoCapturer);
 RTC_FWD_DECL_OBJC_CLASS(RTCVideoSourceAdapter);
 
@@ -30,17 +32,19 @@ class MacCapturer : public ScalableVideoTrackSource,
   static rtc::scoped_refptr<MacCapturer> Create(size_t width,
                                                 size_t height,
                                                 size_t target_fps,
-                                                size_t capture_device_index);
+                                                const std::string& specifiedVideoDevice);
   MacCapturer(size_t width,
               size_t height,
               size_t target_fps,
-              size_t capture_device_index);
+              AVCaptureDevice* device);
   virtual ~MacCapturer();
 
   void OnFrame(const webrtc::VideoFrame& frame) override;
 
  private:
   void Destroy();
+
+  static AVCaptureDevice* FindVideoDevice(const std::string& specifiedVideoDevice);
 
   RTCCameraVideoCapturer* capturer_;
   RTCVideoSourceAdapter* adapter_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
   rtc::LogMessage::AddLogToStream(log_sink.get(), rtc::LS_INFO);
 #ifdef __APPLE__
   rtc::scoped_refptr<MacCapturer> capturer =
-      MacCapturer::Create(cs.getWidth(), cs.getHeight(), cs.framerate, 0);
+      MacCapturer::Create(cs.getWidth(), cs.getHeight(), cs.framerate, cs.video_device);
 #else
 #if USE_MMAL_ENCODER || USE_JETSON_ENCODER
   rtc::scoped_refptr<V4L2VideoCapture> capturer = V4L2VideoCapture::Create(cs);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -178,6 +178,9 @@ void Util::parseArgs(int argc,
   app.add_option("--video-device", cs.video_device,
                  "デバイスファイル名。省略時はどれかのビデオデバイスを自動検出")
       ->check(CLI::ExistingFile);
+#elif __APPLE__
+  app.add_option("--video-device", cs.video_device,
+                 "デバイス番号、またはデバイス名。省略時はデフォルト（デバイス番号が0）のビデオデバイスを自動検出");
 #endif
   app.add_set("--resolution", cs.resolution, {"QVGA", "VGA", "HD", "FHD", "4K"},
               "解像度");


### PR DESCRIPTION
#104 の提案実装

## デバイスの指定方法

#57 でデバイスの指定方法について、デバイス番号がデバイス名かで議論がありましたが、この提案では両方をサポートします。指定方法は、[ffmpeg の avfoundation の指定方法](https://ffmpeg.org/ffmpeg-devices.html#Examples)を参考にしています。

* 指定がない場合は、現行と同じくデバイス番号が0のものが選択される
* デバイス番号 0 のエイリアスとして、`default` が使える
* デバイス名を指定した場合は、デバイス番号0から順番に検索していき、前方一致検索で最初にまっちしたものが選択される

なお、`default` については、余計な機能かもしれないため、削除するでも良いです。

## 例

### デフォルトデバイス指定

下記は全て同じデフォルトデバイスが選択されます。

```console
$ ./momo test
$ ./momo --video-device 0 test
$ ./momo --video-device default test
$ ./momo --video-device "default" test
```

### デバイス番号で指定

```console
$ ./momo --video-device 1 test
```

### デバイス名で指定

前方一致検索でマッチさせるため、下記は全て同じデバイスが選択されます。

```console
$ ./momo --video-device FaceTime test
$ ./momo --video-device "FaceTime HD" 1 test
$ ./momo --video-device "FaceTime HD Camera (Built-in)" test
```