### PR TITLE
[Ayame] isExistUser フラグが accept 時に返却されなかった場合 2 回 peer connection を生成する

### DIFF
--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -332,7 +332,7 @@ void AyameWebsocketClient::onRead(boost::system::error_code ec,
       RTC_LOG(LS_INFO) << __FUNCTION__ << ": exist_user";
       is_send_offer_ = true;
       connection_->createOffer();
-    } else if (!has_is_exist_user_flag_){
+    } else if (!has_is_exist_user_flag_) {
       // フラグがない場合とりあえず送信
       connection_->createOffer();
     }

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -421,7 +421,7 @@ void AyameWebsocketClient::doIceConnectionStateChange(
   rtc_state_ = new_state;
 }
 
-void doSetDescription(webrtc::SdpType type) {
+void AyameWebSocketClient::doSetDescription(webrtc::SdpType type) {
   if (type == webrtc::SdpType::kOffer) {
     if (!is_send_offer_ || !has_is_exist_user_flag_) {
       connection_->createAnswer();

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -421,7 +421,7 @@ void AyameWebsocketClient::doIceConnectionStateChange(
   rtc_state_ = new_state;
 }
 
-void AyameWebSocketClient::doSetDescription(webrtc::SdpType type) {
+void AyameWebsocketClient::doSetDescription(webrtc::SdpType type) {
   if (type == webrtc::SdpType::kOffer) {
     if (!is_send_offer_ || !has_is_exist_user_flag_) {
       connection_->createAnswer();

--- a/src/ayame/ayame_websocket_client.h
+++ b/src/ayame/ayame_websocket_client.h
@@ -40,7 +40,6 @@ class AyameWebsocketClient
 
   bool connected_;
   bool is_send_offer_;
-  bool is_exist_user_;
   bool has_is_exist_user_flag_;
 
   webrtc::PeerConnectionInterface::IceServers ice_servers_;
@@ -114,6 +113,7 @@ class AyameWebsocketClient
  private:
   void doIceConnectionStateChange(
       webrtc::PeerConnectionInterface::IceConnectionState new_state);
+  void doSetDescription(webrtc::SdpType type);
 };
 
 #endif  // AYAME_WEBSOCKET_CLIENT_

--- a/src/ayame/ayame_websocket_client.h
+++ b/src/ayame/ayame_websocket_client.h
@@ -40,6 +40,8 @@ class AyameWebsocketClient
 
   bool connected_;
   bool is_send_offer_;
+  bool is_exist_user_;
+  bool has_is_exist_user_flag_;
 
   webrtc::PeerConnectionInterface::IceServers ice_servers_;
 
@@ -80,8 +82,8 @@ class AyameWebsocketClient
   void onHandshake(boost::system::error_code ec);
   void doRegister();
   void doSendPong();
-  void createPeerConnection(nlohmann::json json_message);
-  ;
+  void setIceServersFromConfig(nlohmann::json json_message);
+  void createPeerConnection();
 
  public:
   void close();


### PR DESCRIPTION
Ayame の下方互換性対応です。
#113 で失われた下位互換性を取り戻しています。
accept の返り値に isExistUser 情報がないときは、以前のように peer connection を2回生成するようにしました。
isExistUser フラグがある場合はこれまで通り動作します。

macOS / 各 Ayame バージョンで動作確認済みです。