### PR TITLE
USE_H264が定義されない場合でも--video-codecが使えるように修正

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -158,7 +158,10 @@ void Util::parseArgs(int argc,
 #if MOMO_USE_H264
         return std::string();
 #else
-        return "このデバイスは --video-codec=H264 に対応していません。";
+        if (input == "H264") {
+          return "このデバイスは --video-codec=H264 に対応していません。";
+        }
+        return std::string();
 #endif
       },
       "");


### PR DESCRIPTION
USE_H264が定義されない場合、--video-codecオプションのバリデーターのコードで常にメッセージ文字列を返してしまうためエラーとなってしまう。H264が指定されたときだけメッセージ文字列を返すように修正。