### PR TITLE
[Ayame] momo + ayame モードで再接続時に delay してしまう問題を解決する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [FIX] momo + ayame モードで再接続時に delay してしまう問題を解決
+    - @kdxu
+
 ## 19.12.0
 
 - [UPDATE] libwebrtc M79 コミットポジションを 5 にする

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -314,7 +314,7 @@ void AyameWebsocketClient::onRead(boost::system::error_code ec,
     return;
 
   // WebSocket の Close Frame の場合すぐにWebSocket の再接続を行う
-  if (ec == boost::beast::websocket::error::closed){
+  if (ec == boost::beast::websocket::error::closed) {
     close();
     return;
   }

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -363,10 +363,6 @@ void AyameWebsocketClient::onRead(boost::system::error_code ec,
     candidate = ice["candidate"];
     connection_->addIceCandidate(sdp_mid, sdp_mlineindex, candidate);
   } else if (type == "ping") {
-    if (rtc_state_ != webrtc::PeerConnectionInterface::IceConnectionState::
-                          kIceConnectionConnected) {
-      return;
-    }
     watchdog_.reset();
     doSendPong();
   }

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -311,6 +311,13 @@ void AyameWebsocketClient::onRead(boost::system::error_code ec,
   if (ec == boost::asio::error::operation_aborted)
     return;
 
+  // EOF(WebSocket の Close Frame) の場合すぐにWebSocket の再接続を行う
+  if (ec == boost::asio::error::eof) {
+    retry_count_ = 0;
+    reconnectAfter();
+    return;
+  }
+
   if (ec)
     return MOMO_BOOST_ERROR(ec, "Read");
 

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -278,6 +278,8 @@ void AyameWebsocketClient::createPeerConnection() {
 }
 
 void AyameWebsocketClient::close() {
+  // websocket 接続を閉じる
+  // 閉じられると onClose() にコールバックする
   if (ws_->isSSL()) {
     ws_->nativeSecureSocket().async_close(
         boost::beast::websocket::close_code::normal,
@@ -298,6 +300,8 @@ void AyameWebsocketClient::close() {
 void AyameWebsocketClient::onClose(boost::system::error_code ec) {
   if (ec)
     return MOMO_BOOST_ERROR(ec, "close");
+  // WebSocket 接続がちゃんと閉じられたら `reconnectAfter` を発火して websocket に再接続する
+  // 現在は WebSocket がどんな理由で閉じられても、再接続するようになっている
   retry_count_ = 0;
   reconnectAfter();
 }
@@ -421,6 +425,8 @@ void AyameWebsocketClient::doIceConnectionStateChange(
       break;
     case webrtc::PeerConnectionInterface::IceConnectionState::
         kIceConnectionFailed:
+      // ice connection state が failed になったら websocket ごと閉じて
+      // 再接続処理を行う
       close();
       break;
     default:


### PR DESCRIPTION
この PR は最新リリースバージョンの momo で起きている ayame モードの問題を解決するものです。

これまでは再接続処理で明示的に websocket を閉じていなかったのですが、この変更により、
再接続時は適切に `ws.close()` して、 websocket が閉じてから reconnect することで、ping を受け取ったときの

```cpp
    if (rtc_state_ != webrtc::PeerConnectionInterface::IceConnectionState::	
                          kIceConnectionConnected) {	
      return;	
    }
```

判定が不要になり、これによって無駄な watchdog の expired の発火による再接続処理(=> 遅延接続の根源)を排除しました。

jetson nano と、macOS にて動作検証済みです。
