### PR TITLE
Feature/fix retry

### DIFF
--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -377,6 +377,10 @@ void AyameWebsocketClient::onRead(boost::system::error_code ec,
   } else if (type == "ping") {
     watchdog_.reset();
     doSendPong();
+  } else if (type == "bye") {
+    RTC_LOG(LS_INFO) << __FUNCTION__ << ": bye";
+    connection_ = nullptr;
+    close();
   }
 }
 

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -121,7 +121,7 @@ bool AyameWebsocketClient::connect() {
 }
 
 void AyameWebsocketClient::reconnectAfter() {
-  int interval = 5 * (2 * retry_count_ + 1);
+  int interval = 5 * (2 * retry_count_);
   RTC_LOG(LS_INFO) << __FUNCTION__ << " reconnect after " << interval << " sec";
 
   watchdog_.enable(interval);

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -300,7 +300,7 @@ void AyameWebsocketClient::close() {
 // WebSocket が閉じられたときのコールバック
 void AyameWebsocketClient::onClose(boost::system::error_code ec) {
   if (ec)
-    return MOMO_BOOST_ERROR(ec, "close");
+    MOMO_BOOST_ERROR(ec, "close");
   // retry_count_ は reconnectAfter(); が以前に呼ばれている場合はインクリメントされている可能性がある。
   // WebSocket につないでいない時間をなるべく短くしたいので、
   // WebSocket を閉じたときは一度インクリメントされている可能性のある retry_count_ を0 にして


### PR DESCRIPTION
下記 3 点を修正、変更しました

- WebSocket が閉じられた際に再接続処理に進まない箇所を修正
- シグナリングで bye を受信した際処理として、各 close 処理を追加
- 再接続処理の 1 回目を、5 秒後からすぐに実行されるように変更