### PR TITLE
Windowsでも--video-deviceを指定できるようにした

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,7 +108,8 @@ int main(int argc, char* argv[]) {
     return V4L2VideoCapture::Create(cs);
 #endif
 #else
-    return DeviceVideoCapturer::Create(size.width, size.height, cs.framerate);
+    return DeviceVideoCapturer::Create(size.width, size.height, cs.framerate,
+                                       cs.video_device);
 #endif
 #endif  // USE_ROS
   })();

--- a/src/rtc/device_video_capturer.h
+++ b/src/rtc/device_video_capturer.h
@@ -29,6 +29,11 @@ class DeviceVideoCapturer : public ScalableVideoTrackSource,
       size_t height,
       size_t target_fps,
       size_t capture_device_index);
+  static rtc::scoped_refptr<DeviceVideoCapturer> Create(
+      size_t width,
+      size_t height,
+      size_t target_fps,
+      const std::string& capture_device);
   DeviceVideoCapturer();
   virtual ~DeviceVideoCapturer();
 
@@ -41,6 +46,9 @@ class DeviceVideoCapturer : public ScalableVideoTrackSource,
 
   // rtc::VideoSinkInterface interface.
   void OnFrame(const webrtc::VideoFrame& frame) override;
+
+  int LogDeviceInfo();
+  int GetDeviceIndex(const std::string& device);
 
   rtc::scoped_refptr<webrtc::VideoCaptureModule> vcm_;
   webrtc::VideoCaptureCapability capability_;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -211,7 +211,7 @@ void Util::parseArgs(int argc,
                "Perform MJPEG deoode and video resize by hardware acceleration "
                "(only on supported devices)")
       ->check(is_valid_use_native);
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_WIN32)
   app.add_option("--video-device", cs.video_device,
                  "Use the video device specified by an index or a name "
                  "(use the first one if not specified)");


### PR DESCRIPTION
mac版の動きに合わせて、デバイス名とデバイスID（OSが認識する順番の0始まり）のどちらでも指定できるようにしてあります。

現在、DeviceVideoCapturerクラスは、事実上Windows専用になっているのでDeviceVideoCapturerクラスを修正しています。（過去の実装ではDeviceVideoCapturerクラスは、ハードウェアエンコーダを利用しないLinuxでも利用されている汎用的なCapturerクラスでした。

現在はLinuxはV4L2VideoCaptureを利用するため、WindowsでしかDeviceVideoCapturerクラスを使わないはずです。）この前提がまずいようでしたら、別の実装方法で出し直しますので突っ込んでください。
