### PR TITLE
video_adapter_メンバ変数は使用していないので削除する

### DIFF
--- a/src/rtc/scalable_track_source.h
+++ b/src/rtc/scalable_track_source.h
@@ -34,8 +34,6 @@ class ScalableVideoTrackSource : public rtc::AdaptedVideoTrackSource {
 
  private:
   rtc::TimestampAligner timestamp_aligner_;
-
-  cricket::VideoAdapter video_adapter_;
 };
 
 #endif  // VIDEO_CAPTURER_H_


### PR DESCRIPTION
ScalableVideoTrackSource::video_adapter_ メンバは、必要ないので削除します。
ScalableVideoTrackSourceの親クラスAdaptedVideoTrackSourceクラスに同名のメンバがあり、隠蔽している状態です。親クラスではAdaptFrame()メソッド内で使用されていますが、子クラスのScalableVideoTrackSourceクラスには必要ありません。
（おそらく、修正漏れか何かでずっと残っていたのだと思います。消しても消さなくても問題はありませんが、消すことでわずかにメモリ使用量が減ります）
