### PR TITLE
Ayame の type を test に追加

### DIFF
--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -283,7 +283,7 @@ void AyameWebsocketClient::setIceServersFromConfig(json json_message) {
       }
     }
   }
-  if (ice_servers_.empty()) {
+  if (ice_servers_.empty() && !conn_settings_.no_google_stun) {
     // accept 時に iceServers が返却されてこなかった場合 google の stun server を用いる
     webrtc::PeerConnectionInterface::IceServer ice_server;
     ice_server.uri = "stun:stun.l.google.com:19302";

--- a/src/ayame/ayame_websocket_client.cpp
+++ b/src/ayame/ayame_websocket_client.cpp
@@ -140,6 +140,9 @@ bool AyameWebsocketClient::connect() {
 
 void AyameWebsocketClient::reconnectAfter() {
   int interval = 5 * (2 * retry_count_);
+  if (interval > 30) {
+    interval = 30;
+  }
   RTC_LOG(LS_INFO) << __FUNCTION__ << " reconnect after " << interval << " sec";
 
   watchdog_.enable(interval);

--- a/src/connection_settings.h
+++ b/src/connection_settings.h
@@ -16,6 +16,7 @@ struct ConnectionSettings {
   int audio_topic_ch = 1;
 #endif
 
+  bool no_google_stun = false;
   bool no_video_device = false;
   bool no_audio_device = false;
   bool force_i420 = false;
@@ -106,6 +107,8 @@ struct ConnectionSettings {
 
   friend std::ostream& operator<<(std::ostream& os,
                                   const ConnectionSettings& cs) {
+    os << "no_google_stun: " << (cs.no_google_stun ? "true" : "false")
+       << "\n";
     os << "no_video_device: " << (cs.no_video_device ? "true" : "false")
        << "\n";
     os << "no_audio_device: " << (cs.no_audio_device ? "true" : "false")

--- a/src/p2p/p2p_connection.cpp
+++ b/src/p2p/p2p_connection.cpp
@@ -9,13 +9,16 @@ using json = nlohmann::json;
 using IceConnectionState = webrtc::PeerConnectionInterface::IceConnectionState;
 
 P2PConnection::P2PConnection(RTCManager* rtc_manager,
+                             ConnectionSettings conn_settings,
                              std::function<void(std::string)> send)
     : _send(send) {
   webrtc::PeerConnectionInterface::RTCConfiguration rtc_config;
   webrtc::PeerConnectionInterface::IceServers servers;
-  webrtc::PeerConnectionInterface::IceServer ice_server;
-  ice_server.uri = "stun:stun.l.google.com:19302";
-  servers.push_back(ice_server);
+  if (!conn_settings.no_google_stun) {
+    webrtc::PeerConnectionInterface::IceServer ice_server;
+    ice_server.uri = "stun:stun.l.google.com:19302";
+    servers.push_back(ice_server);
+  }
   rtc_config.servers = servers;
   _connection = rtc_manager->createConnection(rtc_config, this);
 }

--- a/src/p2p/p2p_connection.h
+++ b/src/p2p/p2p_connection.h
@@ -11,7 +11,9 @@
 
 class P2PConnection : public RTCMessageSender {
  public:
-  P2PConnection(RTCManager* rtc_manager, std::function<void(std::string)> send);
+  P2PConnection(RTCManager* rtc_manager,
+                ConnectionSettings conn_settings,
+                std::function<void(std::string)> send);
   ~P2PConnection() {}
 
   webrtc::PeerConnectionInterface::IceConnectionState getRTCConnectionState() {

--- a/src/p2p/p2p_server.cpp
+++ b/src/p2p/p2p_server.cpp
@@ -8,7 +8,8 @@ P2PServer::P2PServer(boost::asio::io_context& ioc,
                      std::shared_ptr<std::string const> const& doc_root,
                      RTCManager* rtc_manager,
                      ConnectionSettings conn_settings)
-    : acceptor_(ioc),
+    : ioc_(ioc),
+      acceptor_(ioc),
       socket_(ioc),
       doc_root_(doc_root),
       rtc_manager_(rtc_manager),
@@ -60,7 +61,7 @@ void P2PServer::onAccept(boost::system::error_code ec) {
   if (ec) {
     MOMO_BOOST_ERROR(ec, "accept");
   } else {
-    std::make_shared<P2PSession>(std::move(socket_), doc_root_, rtc_manager_,
+    std::make_shared<P2PSession>(ioc_, std::move(socket_), doc_root_, rtc_manager_,
                                  conn_settings_)
         ->run();
   }

--- a/src/p2p/p2p_server.h
+++ b/src/p2p/p2p_server.h
@@ -12,6 +12,7 @@
 #include "util.h"
 
 class P2PServer : public std::enable_shared_from_this<P2PServer> {
+  boost::asio::io_context& ioc_;
   boost::asio::ip::tcp::acceptor acceptor_;
   boost::asio::ip::tcp::socket socket_;
   std::shared_ptr<std::string const> doc_root_;

--- a/src/p2p/p2p_session.cpp
+++ b/src/p2p/p2p_session.cpp
@@ -15,11 +15,13 @@
 
 #include "util.h"
 
-P2PSession::P2PSession(boost::asio::ip::tcp::socket socket,
+P2PSession::P2PSession(boost::asio::io_context& ioc,
+                       boost::asio::ip::tcp::socket socket,
                        std::shared_ptr<std::string const> const& doc_root,
                        RTCManager* rtc_manager,
                        ConnectionSettings conn_settings)
-    : socket_(std::move(socket)),
+    : ioc_(ioc),
+      socket_(std::move(socket)),
       strand_(socket_.get_executor()),
       doc_root_(doc_root),
       rtc_manager_(rtc_manager),
@@ -57,7 +59,7 @@ void P2PSession::onRead(boost::system::error_code ec,
   // WebSocket の upgrade リクエスト
   if (req_.target() == "/ws") {
     if (boost::beast::websocket::is_upgrade(req_)) {
-      P2PWebsocketSession::make_shared(std::move(socket_), rtc_manager_,
+      P2PWebsocketSession::make_shared(ioc_, std::move(socket_), rtc_manager_,
                                        conn_settings_)
           ->run(std::move(req_));
       return;

--- a/src/p2p/p2p_session.h
+++ b/src/p2p/p2p_session.h
@@ -20,6 +20,7 @@
 
 // 1つの HTTP リクエストを処理するためのクラス
 class P2PSession : public std::enable_shared_from_this<P2PSession> {
+  boost::asio::io_context& ioc_;
   boost::asio::ip::tcp::socket socket_;
   boost::asio::strand<boost::asio::ip::tcp::socket::executor_type> strand_;
   boost::beast::flat_buffer buffer_;
@@ -31,7 +32,8 @@ class P2PSession : public std::enable_shared_from_this<P2PSession> {
   ConnectionSettings conn_settings_;
 
  public:
-  P2PSession(boost::asio::ip::tcp::socket socket,
+  P2PSession(boost::asio::io_context& ioc,
+             boost::asio::ip::tcp::socket socket,
              std::shared_ptr<std::string const> const& doc_root,
              RTCManager* rtc_manager,
              ConnectionSettings conn_settings);

--- a/src/p2p/p2p_websocket_session.cpp
+++ b/src/p2p/p2p_websocket_session.cpp
@@ -131,8 +131,14 @@ void P2PWebsocketSession::onRead(boost::system::error_code ec,
     }
     std::shared_ptr<RTCConnection> rtc_conn = p2p_conn->getRTCConnection();
     rtc_conn->addIceCandidate(sdp_mid, sdp_mlineindex, candidate);
-  } else if (type == "close") {
+  } else if (type == "close" || type == "bye") {
     connection_ = nullptr;
+  } else if (type == "register") {
+    json accept_message = {
+        {"type", "accept"},
+        {"isExistUser", true},
+    };
+    ws_->sendText(accept_message.dump());
   } else {
     return;
   }

--- a/src/p2p/p2p_websocket_session.cpp
+++ b/src/p2p/p2p_websocket_session.cpp
@@ -9,9 +9,12 @@
 
 using json = nlohmann::json;
 
-P2PWebsocketSession::P2PWebsocketSession(RTCManager* rtc_manager,
+P2PWebsocketSession::P2PWebsocketSession(boost::asio::io_context& ioc,
+                                         RTCManager* rtc_manager,
                                          ConnectionSettings conn_settings)
-    : rtc_manager_(rtc_manager), conn_settings_(conn_settings) {
+    : rtc_manager_(rtc_manager), conn_settings_(conn_settings),
+      watchdog_(ioc,
+                std::bind(&P2PWebsocketSession::onWatchdogExpired, this)) {
   RTC_LOG(LS_INFO) << __FUNCTION__;
 }
 
@@ -20,10 +23,11 @@ P2PWebsocketSession::~P2PWebsocketSession() {
 }
 
 std::shared_ptr<P2PWebsocketSession> P2PWebsocketSession::make_shared(
+    boost::asio::io_context& ioc,
     boost::asio::ip::tcp::socket socket,
     RTCManager* rtc_manager,
     ConnectionSettings conn_settings) {
-  auto p = std::make_shared<P2PWebsocketSession>(rtc_manager, conn_settings);
+  auto p = std::make_shared<P2PWebsocketSession>(ioc, rtc_manager, conn_settings);
   p->ws_ = std::unique_ptr<Websocket>(new Websocket(std::move(socket)));
   return p;
 }
@@ -32,6 +36,14 @@ void P2PWebsocketSession::run(
     boost::beast::http::request<boost::beast::http::string_body> req) {
   RTC_LOG(LS_INFO) << __FUNCTION__;
   doAccept(std::move(req));
+}
+
+void P2PWebsocketSession::onWatchdogExpired() {
+    json ping_message = {
+        {"type", "ping"},
+    };
+    ws_->sendText(std::move(ping_message.dump()));
+    watchdog_.reset();
 }
 
 void P2PWebsocketSession::doAccept(
@@ -138,7 +150,8 @@ void P2PWebsocketSession::onRead(boost::system::error_code ec,
         {"type", "accept"},
         {"isExistUser", true},
     };
-    ws_->sendText(accept_message.dump());
+    ws_->sendText(std::move(accept_message.dump()));
+    watchdog_.enable(30);
   } else {
     return;
   }

--- a/src/p2p/p2p_websocket_session.cpp
+++ b/src/p2p/p2p_websocket_session.cpp
@@ -98,7 +98,7 @@ void P2PWebsocketSession::onRead(boost::system::error_code ec,
     auto send = std::bind([](P2PWebsocketSession* session,
                              std::string str) { session->ws_->sendText(str); },
                           this, std::placeholders::_1);
-    connection_ = std::make_shared<P2PConnection>(rtc_manager_, send);
+    connection_ = std::make_shared<P2PConnection>(rtc_manager_, conn_settings_, send);
     std::shared_ptr<RTCConnection> rtc_conn = connection_->getRTCConnection();
     rtc_conn->setOffer(sdp);
   } else if (type == "answer") {

--- a/src/p2p/p2p_websocket_session.h
+++ b/src/p2p/p2p_websocket_session.h
@@ -14,6 +14,7 @@
 #include "p2p_connection.h"
 #include "rtc/manager.h"
 #include "util.h"
+#include "watchdog.h"
 #include "ws/websocket.h"
 
 class P2PWebsocketSession
@@ -21,21 +22,26 @@ class P2PWebsocketSession
   std::unique_ptr<Websocket> ws_;
   boost::beast::multi_buffer sending_buffer_;
 
+  WatchDog watchdog_;
+
   RTCManager* rtc_manager_;
   ConnectionSettings conn_settings_;
   std::shared_ptr<P2PConnection> connection_;
 
  public:
-  P2PWebsocketSession(RTCManager* rtc_manager,
+  P2PWebsocketSession(boost::asio::io_context& ioc,
+                      RTCManager* rtc_manager,
                       ConnectionSettings conn_settings);
   ~P2PWebsocketSession();
   static std::shared_ptr<P2PWebsocketSession> make_shared(
+      boost::asio::io_context& ioc,
       boost::asio::ip::tcp::socket socket,
       RTCManager* rtc_manager,
       ConnectionSettings conn_settings);
   void run(boost::beast::http::request<boost::beast::http::string_body> req);
 
  private:
+  void onWatchdogExpired();
   void doAccept(
       boost::beast::http::request<boost::beast::http::string_body> req);
   void onAccept(boost::system::error_code ec);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -54,6 +54,8 @@ void Util::parseArgs(int argc,
   local_nh.param<bool>("use_ayame", use_ayame, use_ayame);
   local_nh.param<bool>("use_sora", use_sora, use_sora);
 
+  local_nh.param<bool>("no_google_stun", cs.no_google_stun,
+                       cs.no_google_stun);
   local_nh.param<bool>("no_video_device", cs.no_video_device,
                        cs.no_video_device);
   local_nh.param<bool>("no_audio_device", cs.no_audio_device,
@@ -206,6 +208,8 @@ void Util::parseArgs(int argc,
       },
       "");
 
+  app.add_flag("--no-google-stun", cs.no_google_stun,
+               "Do not use google stun");
   app.add_flag("--no-video-device", cs.no_video_device,
                "Do not use video device");
   app.add_flag("--no-audio-device", cs.no_audio_device,


### PR DESCRIPTION
[医療機関向けお手軽テレビ電話システムを構築したお話](https://note.com/tanpoponet/n/nf0493f18dc8a) に呼応する形で機能追加を実施します。

もともと test モードにおいて WebSocket Server を動作させていたのを利用し、ayame 特有の type である register => accept を test モードに追加することで ayame モードの Momo との直接通信を可能とします。

Momo を搭載した PC が同一ネットワーク下にある場合は

Momo 1: `./momo --use-sdl --show-me test`
Momo 2: `./momo --use-sdl --show-me ayame ws://[Momo 1のIPアドレス]:8080/ws test`

で起動することにより、相互接続可能になります。

ToDo: ~Google STUN を追加しないオプションを追加する~
35d7d68 で対応 `--no-google-stun` オプションで Google STUN を追加しない
 