### PR TITLE
build.sh の --no-tty オプションのヘルプメッセージの修正

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -17,7 +17,7 @@ _PACKAGES=" \
 "
 
 function show_help() {
-  echo "$PROGRAM [--clean] [--package] [--no-cache] [-no-tty] [--no-mount] <package>"
+  echo "$PROGRAM [--clean] [--package] [--no-cache] [--no-tty] [--no-mount] <package>"
   echo "<package>:"
   for package in $_PACKAGES; do
     echo "  - $package"


### PR DESCRIPTION
`--no-tty` オプションの `-` が１つ足りなかったのを直しました。 