### PR TITLE
利用できるエンコーダ/デコーダの一覧を表示する機能を実装

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -195,7 +195,7 @@ void Util::parseArgs(int argc,
       },
       "");
 
-  app.add_flag("--video-codecs", video_codecs,
+  app.add_flag("--video-codec-engines", video_codecs,
                "List available video encoders/decoders");
   app.add_flag("--no-google-stun", cs.no_google_stun,
                "Do not use google stun");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -131,6 +131,7 @@ void Util::parseArgs(int argc,
                         "Print help message for all modes and exit");
 
   bool version = false;
+  bool video_codecs = false;
 
   auto is_valid_force_i420 = CLI::Validator(
       [](std::string input) -> std::string {
@@ -194,6 +195,8 @@ void Util::parseArgs(int argc,
       },
       "");
 
+  app.add_flag("--video-codecs", video_codecs,
+               "List available video encoders/decoders");
   app.add_flag("--no-google-stun", cs.no_google_stun,
                "Do not use google stun");
   app.add_flag("--no-video-device", cs.no_video_device,
@@ -407,6 +410,11 @@ void Util::parseArgs(int argc,
     exit(0);
   }
 
+  if (video_codecs) {
+    ShowVideoCodecs(VideoCodecInfo::Get());
+    exit(0);
+  }
+
   if (!test_app->parsed() && !sora_app->parsed() && !ayame_app->parsed()) {
     std::cout << app.help() << std::endl;
     exit(1);
@@ -426,6 +434,56 @@ void Util::parseArgs(int argc,
 }
 
 #endif
+
+void Util::ShowVideoCodecs(VideoCodecInfo info) {
+  // VP8:
+  //   Encoder:
+  //     - Software (default)
+  //   Decoder:
+  //     - Jetson (default)
+  //     - Software
+  //
+  // VP9:
+  //   Encoder:
+  //     - Software (default)
+  // ...
+  //
+  // みたいな感じに出力する
+  auto list_codecs = [](std::vector<VideoCodecInfo::Type> types) {
+    for (int i = 0; i < types.size(); i++) {
+      auto type = types[i];
+      auto p = VideoCodecInfo::TypeToString(type);
+      std::cout << "    - " << p.first;
+      if (i == 0) {
+        std::cout << " (default)";
+      }
+      std::cout << std::endl;
+    }
+  };
+  std::cout << "VP8:" << std::endl;
+  std::cout << "  Encoder:" << std::endl;
+  list_codecs(info.vp8_encoders);
+  std::cout << "  Decoder:" << std::endl;
+  list_codecs(info.vp8_decoders);
+  std::cout << "" << std::endl;
+  std::cout << "VP9:" << std::endl;
+  std::cout << "  Encoder:" << std::endl;
+  list_codecs(info.vp9_encoders);
+  std::cout << "  Decoder:" << std::endl;
+  list_codecs(info.vp9_decoders);
+  std::cout << "" << std::endl;
+  std::cout << "AV1:" << std::endl;
+  std::cout << "  Encoder:" << std::endl;
+  list_codecs(info.av1_encoders);
+  std::cout << "  Decoder:" << std::endl;
+  list_codecs(info.av1_decoders);
+  std::cout << "" << std::endl;
+  std::cout << "H264:" << std::endl;
+  std::cout << "  Encoder:" << std::endl;
+  list_codecs(info.h264_encoders);
+  std::cout << "  Decoder:" << std::endl;
+  list_codecs(info.h264_decoders);
+}
 
 std::string Util::generateRandomChars() {
   return generateRandomChars(32);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -450,6 +450,11 @@ void Util::ShowVideoCodecs(VideoCodecInfo info) {
   //
   // みたいな感じに出力する
   auto list_codecs = [](std::vector<VideoCodecInfo::Type> types) {
+    if (types.empty()) {
+      std::cout << "    *UNAVAILABLE*" << std::endl;
+      return;
+    }
+
     for (int i = 0; i < types.size(); i++) {
       auto type = types[i];
       auto p = VideoCodecInfo::TypeToString(type);

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,7 @@
 
 #include "api/peer_connection_interface.h"
 #include "connection_settings.h"
+#include "video_codec_info.h"
 
 class Util {
  public:
@@ -38,6 +39,9 @@ class Util {
   serverError(
       const boost::beast::http::request<boost::beast::http::string_body>& req,
       boost::beast::string_view what);
+
+ private:
+  static void ShowVideoCodecs(VideoCodecInfo info);
 };
 
 // boost::system::error_code のエラーをいい感じに出力するマクロ

--- a/src/video_codec_info.h
+++ b/src/video_codec_info.h
@@ -1,0 +1,138 @@
+#ifndef VIDEO_CODEC_INFO_H_
+#define VIDEO_CODEC_INFO_H_
+
+#if USE_NVCODEC_ENCODER
+#include "hwenc_nvcodec/nvcodec_h264_encoder.h"
+#endif
+
+struct VideoCodecInfo {
+  enum class Type {
+    Jetson,
+    MMAL,
+    NVIDIA,
+    Intel,
+    VideoToolbox,
+    Software,
+    Auto,
+  };
+
+  std::vector<Type> vp8_encoders;
+  std::vector<Type> vp8_decoders;
+
+  std::vector<Type> vp9_encoders;
+  std::vector<Type> vp9_decoders;
+
+  std::vector<Type> av1_encoders;
+  std::vector<Type> av1_decoders;
+
+  std::vector<Type> h264_encoders;
+  std::vector<Type> h264_decoders;
+
+  static std::pair<std::string, std::string> TypeToString(Type type) {
+    switch (type) {
+      case Type::Jetson:
+        return {"Jetson", "jetson"};
+      case Type::MMAL:
+        return {"MMAL", "mmal"};
+      case Type::NVIDIA:
+        return {"NVIDIA VIDEO CODEC SDK", "nvidia"};
+      case Type::Intel:
+        return {"Intel Media SDK", "intel"};
+      case Type::VideoToolbox:
+        return {"VideoToolbox", "videotoolbox"};
+      case Type::Software:
+        return {"Software", "software"};
+      default:
+        return {"Unknown", "unknown"};
+    }
+  }
+
+  static VideoCodecInfo Get() {
+#if defined(_WIN32)
+    return GetWindows();
+#elif defined(__APPLE__)
+    return GetMacos();
+#elif defined(__linux__)
+    return GetLinux();
+#endif
+  }
+
+ private:
+#if defined(_WIN32)
+
+  static VideoCodecInfo GetWindows() {
+    VideoCodecInfo info;
+
+#if USE_NVCODEC_ENCODER
+    if (NvCodecH264Encoder::IsSupported()) {
+      info.h264_encoders.push_back(Type::NVIDIA);
+    }
+#endif
+
+    info.vp8_encoders.push_back(Type::Software);
+    info.vp8_decoders.push_back(Type::Software);
+    info.vp9_encoders.push_back(Type::Software);
+    info.vp9_decoders.push_back(Type::Software);
+    info.av1_encoders.push_back(Type::Software);
+    info.av1_decoders.push_back(Type::Software);
+
+    return info;
+  }
+
+#elif defined(__APPLE__)
+
+  static VideoCodecInfo GetMacos() {
+    VideoCodecInfo info;
+
+    info.h264_encoders.push_back(Type::VideoToolbox);
+    info.h264_decoders.push_back(Type::VideoToolbox);
+    info.vp8_encoders.push_back(Type::Software);
+    info.vp9_encoders.push_back(Type::Software);
+    info.vp8_decoders.push_back(Type::Software);
+    info.vp9_decoders.push_back(Type::Software);
+    info.av1_encoders.push_back(Type::Software);
+    info.av1_decoders.push_back(Type::Software);
+
+    return info;
+  }
+
+#elif defined(__linux__)
+
+  static VideoCodecInfo GetLinux() {
+    VideoCodecInfo info;
+
+#if USE_NVCODEC_ENCODER
+    if (NvCodecH264Encoder::IsSupported()) {
+      info.h264_encoders.push_back(Type::NVIDIA);
+    }
+#endif
+
+#if USE_MMAL_ENCODER
+    info.h264_encoders.push_back(Type::MMAL);
+    info.h264_decoders.push_back(Type::MMAL);
+#endif
+
+#if USE_JETSON_ENCODER
+    info.h264_encoders.push_back(Type::Jetson);
+    info.h264_decoders.push_back(Type::Jetson);
+    info.vp8_decoders.push_back(Type::Jetson);
+    info.vp9_decoders.push_back(Type::Jetson);
+#endif
+
+    info.vp8_encoders.push_back(Type::Software);
+    info.vp8_decoders.push_back(Type::Software);
+    info.vp9_encoders.push_back(Type::Software);
+    info.vp9_decoders.push_back(Type::Software);
+
+#if !defined(__arm__) || defined(__aarch64__) || defined(__ARM_NEON__)
+    info.av1_encoders.push_back(Type::Software);
+    info.av1_decoders.push_back(Type::Software);
+#endif
+
+    return info;
+  }
+
+#endif
+};
+
+#endif  // VIDEO_CODEC_INFO_H_


### PR DESCRIPTION
`--video-codec-engines` を使うと、例えば Jetson Nano なら以下のように表示されます。

```
$ ./momo --video-codec-engines
VP8:
  Encoder:
    - Software (default)
  Decoder:
    - Jetson (default)
    - Software

VP9:
  Encoder:
    - Software (default)
  Decoder:
    - Jetson (default)
    - Software

AV1:
  Encoder:
    - Software (default)
  Decoder:
    - Software (default)

H264:
  Encoder:
    - Jetson (default)
  Decoder:
    - Jetson (default)
```

どのエンジンを利用するかを指定する機能は未実装です。あくまで列挙するだけです。