### PR TITLE
Jetson VP8 ハードウェアエンコーダ対応の追加

### DIFF
--- a/src/hwenc_jetson/jetson_video_encoder.cpp
+++ b/src/hwenc_jetson/jetson_video_encoder.cpp
@@ -992,6 +992,7 @@ int32_t JetsonVideoEncoder::SendFrame(unsigned char* buffer, size_t size) {
       webrtc::vp8::GetQp(buffer, size, &encoded_image_.qp_);
       sending_encoded_image_->qp_ = encoded_image_.qp_;
       codec_specific.codecSpecific.VP8.keyIdx = webrtc::kNoKeyIdx;
+      // nonReference かを知ることはできなかった
       codec_specific.codecSpecific.VP8.nonReference = false;
     } else if (codec_.codecType == webrtc::kVideoCodecVP9) {
       webrtc::vp9::GetQp(buffer, size, &encoded_image_.qp_);
@@ -1018,7 +1019,7 @@ int32_t JetsonVideoEncoder::SendFrame(unsigned char* buffer, size_t size) {
         codec_specific.codecSpecific.VP9.gof.CopyGofInfoVP9(gof_);
       }
     }
-    RTC_LOG(LS_VERBOSE) << "key_frame=" << key_frame << " size=" << size
+    RTC_LOG(LS_ERROR) << "key_frame=" << key_frame << " size=" << size
                         << " qp=" << encoded_image_.qp_;
   }
 

--- a/src/hwenc_jetson/jetson_video_encoder.cpp
+++ b/src/hwenc_jetson/jetson_video_encoder.cpp
@@ -1019,7 +1019,7 @@ int32_t JetsonVideoEncoder::SendFrame(unsigned char* buffer, size_t size) {
         codec_specific.codecSpecific.VP9.gof.CopyGofInfoVP9(gof_);
       }
     }
-    RTC_LOG(LS_ERROR) << "key_frame=" << key_frame << " size=" << size
+    RTC_LOG(LS_VERBOSE) << "key_frame=" << key_frame << " size=" << size
                         << " qp=" << encoded_image_.qp_;
   }
 

--- a/src/hwenc_jetson/jetson_video_encoder.h
+++ b/src/hwenc_jetson/jetson_video_encoder.h
@@ -41,6 +41,7 @@ class JetsonVideoEncoder : public webrtc::VideoEncoder {
   explicit JetsonVideoEncoder(const cricket::VideoCodec& codec);
   ~JetsonVideoEncoder() override;
 
+  static bool IsSupportedVP8();
   static bool IsSupportedVP9();
 
   int32_t InitEncode(const webrtc::VideoCodec* codec_settings,

--- a/src/rtc/momo_video_encoder_factory.cpp
+++ b/src/rtc/momo_video_encoder_factory.cpp
@@ -56,8 +56,8 @@ MomoVideoEncoderFactory::GetSupportedFormats() const {
   std::vector<webrtc::SdpVideoFormat> supported_codecs;
 
   // VP8
-  // 今のところ Software のみ
-  if (vp8_encoder_ == VideoCodecInfo::Type::Software) {
+  if (vp8_encoder_ == VideoCodecInfo::Type::Software ||
+      vp8_encoder_ == VideoCodecInfo::Type::Jetson) {
     supported_codecs.push_back(webrtc::SdpVideoFormat(cricket::kVp8CodecName));
   }
 
@@ -127,6 +127,14 @@ MomoVideoEncoderFactory::CreateVideoEncoder(
         return webrtc::VP8Encoder::Create();
       });
     }
+#if USE_JETSON_ENCODER
+    if (vp8_encoder_ == VideoCodecInfo::Type::Jetson) {
+      return WithSimulcast(format, [](const webrtc::SdpVideoFormat& format) {
+        return std::unique_ptr<webrtc::VideoEncoder>(
+            absl::make_unique<JetsonVideoEncoder>(cricket::VideoCodec(format)));
+      });
+    }
+#endif
   }
 
   if (absl::EqualsIgnoreCase(format.name, cricket::kVp9CodecName)) {

--- a/src/video_codec_info.h
+++ b/src/video_codec_info.h
@@ -152,6 +152,9 @@ struct VideoCodecInfo {
 #if USE_JETSON_ENCODER
     info.h264_encoders.push_back(Type::Jetson);
     info.h264_decoders.push_back(Type::Jetson);
+    if (JetsonVideoEncoder::IsSupportedVP8()) {
+      info.vp8_encoders.push_back(Type::Jetson);
+    }
     info.vp8_decoders.push_back(Type::Jetson);
     info.vp9_decoders.push_back(Type::Jetson);
     if (JetsonVideoEncoder::IsSupportedVP9()) {


### PR DESCRIPTION
Jetson Nano 向けに VP8 ハードウェアエンコーダ対応を追加します。
心残りはあまりないです。ここから上を目指すと VP8 Simulcast 向けの特殊処理を取り込むこととなります。

@melpon さん

軽くで良いのでコードのチェックをお願いします。

@torikizi さん

動作確認をお願いできればと思います。NX と AGX ではハードウェアエンコーダにならないのが正常です。

@voluntas さん

マージタイミングをお願いします。できれば M87 の前がいいです。
M87 はエンコーダ周りの書き換え範囲が多い見込みなのであまり衝突させたくない感じです。