### PR TITLE
Jetson で MJPEG USBカメラを使用したときのCPU使用率を削減する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,6 +594,8 @@ elseif (TARGET_OS STREQUAL "linux")
         target_sources(momo
           PRIVATE
             src/hwenc_jetson/jetson_buffer.cpp
+            src/hwenc_jetson/jetson_jpeg_decoder.cpp
+            src/hwenc_jetson/jetson_jpeg_decoder_pool.cpp
             src/hwenc_jetson/jetson_v4l2_capturer.cpp
             src/hwenc_jetson/jetson_video_encoder.cpp
             src/hwenc_jetson/jetson_video_decoder.cpp

--- a/src/hwenc_jetson/jetson_buffer.cpp
+++ b/src/hwenc_jetson/jetson_buffer.cpp
@@ -18,7 +18,7 @@ rtc::scoped_refptr<JetsonBuffer> JetsonBuffer::Create(
     int scaled_height,
     int fd,
     uint32_t pixfmt,
-    std::shared_ptr<NvJPEGDecoder> decoder) {
+    std::shared_ptr<JetsonJpegDecoder> decoder) {
   return new rtc::RefCountedObject<JetsonBuffer>(
       video_type,
       raw_width,
@@ -190,7 +190,7 @@ uint32_t JetsonBuffer::V4L2PixelFormat() const {
   return pixfmt_;
 }
 
-std::shared_ptr<NvJPEGDecoder> JetsonBuffer::JpegDecoder() const {
+std::shared_ptr<JetsonJpegDecoder> JetsonBuffer::JpegDecoder() const {
   return decoder_;
 }
 
@@ -214,7 +214,7 @@ JetsonBuffer::JetsonBuffer(
     int scaled_height,
     int fd,
     uint32_t pixfmt,
-    std::shared_ptr<NvJPEGDecoder> decoder)
+    std::shared_ptr<JetsonJpegDecoder> decoder)
     : video_type_(video_type),
       raw_width_(raw_width),
       raw_height_(raw_height),

--- a/src/hwenc_jetson/jetson_buffer.h
+++ b/src/hwenc_jetson/jetson_buffer.h
@@ -12,7 +12,8 @@
 
 // Jetson Linux Multimedia API
 #include "nvbuf_utils.h"
-#include "NvJpegDecoder.h"
+
+#include "jetson_jpeg_decoder.h"
 
 class JetsonBuffer : public webrtc::VideoFrameBuffer {
  public:
@@ -24,7 +25,7 @@ class JetsonBuffer : public webrtc::VideoFrameBuffer {
     int scaled_height,
     int fd,
     uint32_t pixfmt,
-    std::shared_ptr<NvJPEGDecoder> decoder);
+    std::shared_ptr<JetsonJpegDecoder> decoder);
 
   static rtc::scoped_refptr<JetsonBuffer> Create(
     webrtc::VideoType video_type,
@@ -43,7 +44,7 @@ class JetsonBuffer : public webrtc::VideoFrameBuffer {
   int RawHeight() const;
   int DecodedFd() const;
   uint32_t V4L2PixelFormat() const;
-  std::shared_ptr<NvJPEGDecoder> JpegDecoder() const;
+  std::shared_ptr<JetsonJpegDecoder> JpegDecoder() const;
   uint8_t* Data() const;
   void SetLength(size_t size);
   size_t Length() const;
@@ -57,7 +58,7 @@ class JetsonBuffer : public webrtc::VideoFrameBuffer {
     int scaled_height,
     int fd,
     uint32_t pixfmt,
-    std::shared_ptr<NvJPEGDecoder> decoder);
+    std::shared_ptr<JetsonJpegDecoder> decoder);
 
   JetsonBuffer(
     webrtc::VideoType video_type,
@@ -74,7 +75,7 @@ class JetsonBuffer : public webrtc::VideoFrameBuffer {
   const int scaled_height_;
   const int fd_;
   const uint32_t pixfmt_;
-  const std::shared_ptr<NvJPEGDecoder> decoder_;
+  const std::shared_ptr<JetsonJpegDecoder> decoder_;
   const std::unique_ptr<uint8_t, webrtc::AlignedFreeDeleter> data_;
   size_t length_;
 };

--- a/src/hwenc_jetson/jetson_jpeg_decoder.cpp
+++ b/src/hwenc_jetson/jetson_jpeg_decoder.cpp
@@ -1,0 +1,20 @@
+#include "jetson_jpeg_decoder.h"
+
+JetsonJpegDecoder::JetsonJpegDecoder(
+    std::shared_ptr<JetsonJpegDecoderPool> pool,
+    std::unique_ptr<NvJPEGDecoder> decoder)
+    : pool_(pool), decoder_(std::move(decoder)) {
+}
+
+JetsonJpegDecoder::~JetsonJpegDecoder() {
+  pool_->Push(std::move(decoder_));
+}
+
+int JetsonJpegDecoder::DecodeToFd(int &fd,
+                                  unsigned char *in_buf,
+                                  unsigned long in_buf_size,
+                                  uint32_t &pixfmt,
+                                  uint32_t &width,
+                                  uint32_t &height) {
+  return decoder_->decodeToFd(fd, in_buf, in_buf_size, pixfmt, width, height);
+}

--- a/src/hwenc_jetson/jetson_jpeg_decoder.h
+++ b/src/hwenc_jetson/jetson_jpeg_decoder.h
@@ -1,0 +1,27 @@
+#ifndef JETSON_JPEG_DECODER_H_
+#define JETSON_JPEG_DECODER_H_
+
+#include <memory>
+
+// Jetson Linux Multimedia API
+#include <NvJpegDecoder.h>
+
+#include "jetson_jpeg_decoder_pool.h"
+
+class JetsonJpegDecoderPool;
+
+class JetsonJpegDecoder {
+ public:
+  JetsonJpegDecoder(std::shared_ptr<JetsonJpegDecoderPool> pool,
+                    std::unique_ptr<NvJPEGDecoder> decoder);
+  ~JetsonJpegDecoder();
+
+  int DecodeToFd(int &fd,
+                 unsigned char *in_buf, unsigned long in_buf_size,
+                 uint32_t &pixfmt, uint32_t &width, uint32_t &height);
+ private:
+  std::shared_ptr<JetsonJpegDecoderPool> pool_;
+  std::unique_ptr<NvJPEGDecoder> decoder_;
+
+};
+#endif  // JETSON_JPEG_DECODER_H_

--- a/src/hwenc_jetson/jetson_jpeg_decoder_pool.cpp
+++ b/src/hwenc_jetson/jetson_jpeg_decoder_pool.cpp
@@ -1,0 +1,21 @@
+#include "jetson_jpeg_decoder_pool.h"
+
+// WebRTC
+#include <rtc_base/logging.h>
+
+std::shared_ptr<JetsonJpegDecoder> JetsonJpegDecoderPool::Pop() {
+  std::unique_ptr<NvJPEGDecoder> nv_decoder;
+  if (decoder_queue_.size() == 0) {
+    nv_decoder.reset(NvJPEGDecoder::createJPEGDecoder("jpegdec"));
+  } else {
+    nv_decoder = std::move(decoder_queue_.front());
+    decoder_queue_.pop();
+  }
+  std::shared_ptr<JetsonJpegDecoder> decoder(
+      new JetsonJpegDecoder(shared_from_this(), std::move(nv_decoder)));
+  return decoder;
+}
+
+void JetsonJpegDecoderPool::Push(std::unique_ptr<NvJPEGDecoder> decoder) {
+  decoder_queue_.push(std::move(decoder));
+}

--- a/src/hwenc_jetson/jetson_jpeg_decoder_pool.cpp
+++ b/src/hwenc_jetson/jetson_jpeg_decoder_pool.cpp
@@ -5,17 +5,23 @@
 
 std::shared_ptr<JetsonJpegDecoder> JetsonJpegDecoderPool::Pop() {
   std::unique_ptr<NvJPEGDecoder> nv_decoder;
-  if (decoder_queue_.size() == 0) {
-    nv_decoder.reset(NvJPEGDecoder::createJPEGDecoder("jpegdec"));
-  } else {
-    nv_decoder = std::move(decoder_queue_.front());
-    decoder_queue_.pop();
+
+  {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (decoder_queue_.size() == 0) {
+      nv_decoder.reset(NvJPEGDecoder::createJPEGDecoder("jpegdec"));
+    } else {
+      nv_decoder = std::move(decoder_queue_.front());
+      decoder_queue_.pop();
+    }
   }
+  
   std::shared_ptr<JetsonJpegDecoder> decoder(
       new JetsonJpegDecoder(shared_from_this(), std::move(nv_decoder)));
   return decoder;
 }
 
 void JetsonJpegDecoderPool::Push(std::unique_ptr<NvJPEGDecoder> decoder) {
+  std::lock_guard<std::mutex> lock(mtx_);
   decoder_queue_.push(std::move(decoder));
 }

--- a/src/hwenc_jetson/jetson_jpeg_decoder_pool.h
+++ b/src/hwenc_jetson/jetson_jpeg_decoder_pool.h
@@ -1,0 +1,23 @@
+#ifndef JETSON_JPEG_DECODER_POOL_H_
+#define JETSON_JPEG_DECODER_POOL_H_
+
+#include <memory>
+#include <queue>
+
+// Jetson Linux Multimedia API
+#include <NvJpegDecoder.h>
+
+#include "jetson_jpeg_decoder.h"
+
+class JetsonJpegDecoder;
+
+class JetsonJpegDecoderPool :
+    public std::enable_shared_from_this<JetsonJpegDecoderPool> {
+ public:
+  std::shared_ptr<JetsonJpegDecoder> Pop();
+  void Push(std::unique_ptr<NvJPEGDecoder> decoder);
+
+ private:
+  std::queue<std::unique_ptr<NvJPEGDecoder>> decoder_queue_;
+};
+#endif  // JETSON_JPEG_DECODER_POOL_H_

--- a/src/hwenc_jetson/jetson_jpeg_decoder_pool.h
+++ b/src/hwenc_jetson/jetson_jpeg_decoder_pool.h
@@ -2,6 +2,7 @@
 #define JETSON_JPEG_DECODER_POOL_H_
 
 #include <memory>
+#include <mutex>
 #include <queue>
 
 // Jetson Linux Multimedia API
@@ -18,6 +19,7 @@ class JetsonJpegDecoderPool :
   void Push(std::unique_ptr<NvJPEGDecoder> decoder);
 
  private:
+  std::mutex mtx_;
   std::queue<std::unique_ptr<NvJPEGDecoder>> decoder_queue_;
 };
 #endif  // JETSON_JPEG_DECODER_POOL_H_

--- a/src/hwenc_jetson/jetson_v4l2_capturer.h
+++ b/src/hwenc_jetson/jetson_v4l2_capturer.h
@@ -3,6 +3,8 @@
 
 #include <v4l2_video_capturer/v4l2_video_capturer.h>
 
+#include "jetson_jpeg_decoder_pool.h"
+
 class JetsonV4L2Capturer : public V4L2VideoCapturer {
  public:
   static rtc::scoped_refptr<V4L2VideoCapturer> Create(V4L2VideoCapturerConfig config);
@@ -13,7 +15,12 @@ class JetsonV4L2Capturer : public V4L2VideoCapturer {
       webrtc::VideoCaptureModule::DeviceInfo* device_info,
       V4L2VideoCapturerConfig config,
       size_t capture_device_index);
+
+  bool AllocateVideoBuffers() override;
+  bool DeAllocateVideoBuffers() override;
   bool OnCaptured(struct v4l2_buffer& buf) override;
+
+  std::shared_ptr<JetsonJpegDecoderPool> jpeg_decoder_pool_;
 };
 
 #endif  // JETSON_V4L2_CAPTURER_H_

--- a/src/hwenc_jetson/jetson_video_encoder.cpp
+++ b/src/hwenc_jetson/jetson_video_encoder.cpp
@@ -666,7 +666,7 @@ int32_t JetsonVideoEncoder::Encode(
   uint8_t* native_data;
   rtc::scoped_refptr<webrtc::VideoFrameBuffer> frame_buffer =
       input_frame.video_frame_buffer();
-  std::shared_ptr<NvJPEGDecoder> decoder;
+  std::shared_ptr<JetsonJpegDecoder> decoder;
   if (frame_buffer->type() == webrtc::VideoFrameBuffer::Type::kNative) {
     use_native_ = true;
     JetsonBuffer* jetson_buffer =

--- a/src/hwenc_jetson/jetson_video_encoder.h
+++ b/src/hwenc_jetson/jetson_video_encoder.h
@@ -27,9 +27,10 @@
 #include "rtc_base/synchronization/mutex.h"
 
 // Jetson Linux Multimedia API
-#include "NvJpegDecoder.h"
 #include "NvVideoConverter.h"
 #include "NvVideoEncoder.h"
+
+#include "jetson_jpeg_decoder.h"
 
 #define CONVERTER_CAPTURE_NUM 2
 
@@ -65,7 +66,7 @@ class JetsonVideoEncoder : public webrtc::VideoEncoder {
                 int64_t rtpts,
                 webrtc::VideoRotation r,
                 absl::optional<webrtc::ColorSpace> c,
-                std::shared_ptr<NvJPEGDecoder> d)
+                std::shared_ptr<JetsonJpegDecoder> d)
         : width(w),
           height(h),
           render_time_ms(rtms),
@@ -84,7 +85,7 @@ class JetsonVideoEncoder : public webrtc::VideoEncoder {
     int64_t timestamp_rtp;
     webrtc::VideoRotation rotation;
     absl::optional<webrtc::ColorSpace> color_space;
-    std::shared_ptr<NvJPEGDecoder> decoder_;
+    std::shared_ptr<JetsonJpegDecoder> decoder_;
   };
 
   int32_t JetsonConfigure();

--- a/src/v4l2_video_capturer/v4l2_video_capturer.h
+++ b/src/v4l2_video_capturer/v4l2_video_capturer.h
@@ -44,11 +44,14 @@ class V4L2VideoCapturer : public ScalableVideoTrackSource {
   int32_t Init(const char* deviceUniqueId,
                const std::string& specifiedVideoDevice);
   virtual int32_t StartCapture(V4L2VideoCapturerConfig config);
-  virtual int32_t StopCapture();
   virtual bool UseNativeBuffer() override;
-  virtual bool OnCaptured(struct v4l2_buffer& buf);
 
  protected:
+  virtual int32_t StopCapture();
+  virtual bool AllocateVideoBuffers();
+  virtual bool DeAllocateVideoBuffers();
+  virtual bool OnCaptured(struct v4l2_buffer& buf);
+
   int32_t _deviceFd;
   int32_t _currentWidth;
   int32_t _currentHeight;
@@ -69,8 +72,6 @@ class V4L2VideoCapturer : public ScalableVideoTrackSource {
 
   enum { kNoOfV4L2Bufffers = 4 };
 
-  bool AllocateVideoBuffers();
-  bool DeAllocateVideoBuffers();
   static void CaptureThread(void*);
   bool CaptureProcess();
 


### PR DESCRIPTION
#170 以降 Jetson で MJPEG デコーダが毎フレーム作られることによって CPU 使用率が2倍以上に増えていたので、Pool にして対処しました。
何故か CPU 使用率は #170 の半分近くまで減少しました。

Nano の H264, VP8 で 30fps 出ることは確認済みです。
NX の H264, VP9 で 30fps 出ることは確認済みです。 

@melpon さん

コードレビューをお願いします。

@torikizi さん

めるぽんさんのレビューが終わったあとに動作確認をお願いします。対象は Jetson のみです。
できれば NX の VP9 でロングランチェックをしたく思います。

以上、よろしくお願いします。