### PR TITLE
JetPack を 4.5 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] JetPack を 4.5 にする
+    - @tnoho
+
 ## 2021.1
 
 - [UPDATE] cmake を 3.19.3 に上げる

--- a/build/ubuntu-18.04_armv8_jetson_nano/arm64.conf
+++ b/build/ubuntu-18.04_armv8_jetson_nano/arm64.conf
@@ -13,11 +13,11 @@ components=main universe
 [Jetson]
 packages=nvidia-l4t-camera nvidia-l4t-multimedia
 source=https://repo.download.nvidia.com/jetson/common
-suite=r32.4
+suite=r32.5
 components=main
 
 [T210]
 packages=nvidia-l4t-jetson-multimedia-api
 source=https://repo.download.nvidia.com/jetson/t210
-suite=r32.4
+suite=r32.5
 components=main

--- a/build/ubuntu-18.04_armv8_jetson_nano/jetson.sh
+++ b/build/ubuntu-18.04_armv8_jetson_nano/jetson.sh
@@ -11,10 +11,6 @@ pushd $SYSDIR/usr/lib/aarch64-linux-gnu
   ln -sf ../../../lib/aarch64-linux-gnu/libdl.so.2 libdl.so
   pushd tegra
     # libnvbuf_utils.so.1.0.0 も同じ
-    ln -sf libnvbuf_utils.so.1.0.0 libnvbuf_utils.so
+    ln -s libnvbuf_fdmap.so.1.0.0 libnvbuf_fdmap.so
   popd
-popd
-
-pushd $SYSDIR/usr/lib/aarch64-linux-gnu/tegra/
-  ln -s libnvbuf_fdmap.so.1.0.0 libnvbuf_fdmap.so
 popd

--- a/build/ubuntu-18.04_armv8_jetson_xavier/arm64.conf
+++ b/build/ubuntu-18.04_armv8_jetson_xavier/arm64.conf
@@ -13,11 +13,11 @@ components=main universe
 [Jetson]
 packages=nvidia-l4t-camera nvidia-l4t-multimedia
 source=https://repo.download.nvidia.com/jetson/common
-suite=r32.4
+suite=r32.5
 components=main
 
 [T194]
 packages=nvidia-l4t-jetson-multimedia-api
 source=https://repo.download.nvidia.com/jetson/t194
-suite=r32.4
+suite=r32.5
 components=main

--- a/build/ubuntu-18.04_armv8_jetson_xavier/jetson.sh
+++ b/build/ubuntu-18.04_armv8_jetson_xavier/jetson.sh
@@ -4,17 +4,7 @@ set -ex
 
 SYSDIR=/root/rootfs
 
-pushd $SYSDIR/usr/lib/aarch64-linux-gnu
-  # 既存の libdl.so は libdl.so -> ../../../lib/aarch64-linux-gnu/libdl.so.2 なのに対して、
-  # Jetson Nano の libdl.so は libdl.so -> /lib/aarch64-linux-gnu/libdl.so.2 になっているため、パスが見つからない。
-  # なので symlink を相対パスで貼り直してやる。
-  ln -sf ../../../lib/aarch64-linux-gnu/libdl.so.2 libdl.so
-  pushd tegra
-    # libnvbuf_utils.so.1.0.0 も同じ
-    ln -sf libnvbuf_utils.so.1.0.0 libnvbuf_utils.so
-  popd
-popd
-
 pushd $SYSDIR/usr/lib/aarch64-linux-gnu/tegra/
+  ln -sf libnvbuf_utils.so.1.0.0 libnvbuf_utils.so
   ln -s libnvbuf_fdmap.so.1.0.0 libnvbuf_fdmap.so
 popd


### PR DESCRIPTION
JetPack を 4.5 に上げました。一部のシンボリックリンクが改善していたため、貼り直すスクリプトを削除してあります。

t210 (Jetson Nano) については動作確認済みです。