### PR TITLE
`--hw-mjpeg-decoder`に説明を追加

### DIFF
--- a/doc/SETUP_JETSON.md
+++ b/doc/SETUP_JETSON.md
@@ -41,6 +41,7 @@ $ tree
 ### --hw-mjpeg-decoder
 
 `--hw-mjpeg-decoder` は ハードウェアによるビデオのリサイズ と USB カメラ用の場合 MJPEG をハードウェアデコードします。
+Jetson シリーズではデフォルトで `--hw-mjpeg-decoder=true` です。 ハードウェアデコードに対応していないコーデックを利用したい場合は `--hw-mjpeg-decoder=false` を指定してください。
 
 ```shell
 $ ./momo --hw-mjpeg-decoder=true --no-audio-device test


### PR DESCRIPTION
- Jetsonシリーズではデフォルトで有効なことを補足しました。