### PR TITLE
ayameモードのヘルプ最新化

### DIFF
--- a/doc/USE.md
+++ b/doc/USE.md
@@ -197,15 +197,14 @@ Options:
 ```
 $ ./momo ayame --help
 Mode for working with WebRTC Signaling Server Ayame
-Usage: ./momo ayame [OPTIONS] SIGNALING-URL ROOM-ID
-
-Positionals:
-  SIGNALING-URL TEXT REQUIRED Signaling URL
-  ROOM-ID TEXT REQUIRED       Room ID
+Usage: ./momo ayame [OPTIONS]
 
 Options:
   -h,--help                   Print this help message and exit
   --help-all                  Print help message for all modes and exit
+  --signaling-url TEXT REQUIRED
+                              Signaling URL
+  --channel-id TEXT REQUIRED  Channel ID
   --client-id TEXT            Client ID
   --signaling-key TEXT        Signaling key
 ```


### PR DESCRIPTION
momoのayameモードでヘルプを表示すると，次の通り表示されます．

```
$ ./momo ayame -h
Mode for working with WebRTC Signaling Server Ayame
Usage: ./momo ayame [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  --help-all                  Print help message for all modes and exit
  --signaling-url TEXT REQUIRED
                              Signaling URL
  --channel-id TEXT REQUIRED  Channel ID
  --client-id TEXT            Client ID
  --signaling-key TEXT        Signaling key$ ./momo ayame -h
Mode for working with WebRTC Signaling Server Ayame
Usage: ./momo ayame [OPTIONS]

Options:
  -h,--help                   Print this help message and exit
  --help-all                  Print help message for all modes and exit
  --signaling-url TEXT REQUIRED
                              Signaling URL
  --channel-id TEXT REQUIRED  Channel ID
  --client-id TEXT            Client ID
  --signaling-key TEXT        Signaling key
```