### PR TITLE
CaptureProcessの終了処理修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 - [UPDATE] cmake を 3.22.1 に上げる
     - @melpon
 
+- [FIX] CaptureProcessの終了処理修正。selectの戻り値(retVal)と終了フラグ(quit_)の参照順を変更
+    - @KaitoYutaka
+
 ## 2021.5.0
 
 - [UPDATE] sdl2 を 2.0.18 に上げる

--- a/src/v4l2_video_capturer/v4l2_video_capturer.cpp
+++ b/src/v4l2_video_capturer/v4l2_video_capturer.cpp
@@ -454,23 +454,23 @@ bool V4L2VideoCapturer::CaptureProcess() {
 
   // _deviceFd written only in StartCapture, when this thread isn't running.
   retVal = select(_deviceFd + 1, &rSet, NULL, NULL, &timeout);
-  if (retVal < 0 && errno != EINTR)  // continue if interrupted
-  {
-    // select failed
-    return false;
-  } else if (retVal == 0) {
-    // select timed out
-    return true;
-  } else if (!FD_ISSET(_deviceFd, &rSet)) {
-    // not event on camera handle
-    return true;
-  }
-
   {
     webrtc::MutexLock lock(&capture_lock_);
 
     if (quit_) {
       return false;
+    }
+
+    if (retVal < 0 && errno != EINTR)  // continue if interrupted
+    {
+      // select failed
+      return false;
+    } if (retVal == 0) {
+      // select timed out
+      return true;
+    } else if (!FD_ISSET(_deviceFd, &rSet)) {
+      // not event on camera handle
+      return true;
     }
 
     if (_captureStarted) {


### PR DESCRIPTION
select timeout時にも、終了フラグ(quit_)の判定処理を行うよう
retValとquit_の参照順を変更