### PR TITLE
不正な MJPEG フレームを後続処理に送らない

### DIFF
--- a/src/hwenc_jetson/jetson_v4l2_capturer.cpp
+++ b/src/hwenc_jetson/jetson_v4l2_capturer.cpp
@@ -9,8 +9,6 @@
 
 #include "jetson_buffer.h"
 
-#define MJPEG_EOS_SEARCH_SIZE 4096
-
 rtc::scoped_refptr<V4L2VideoCapturer> JetsonV4L2Capturer::Create(
     V4L2VideoCapturerConfig config) {
   rtc::scoped_refptr<V4L2VideoCapturer> capturer;
@@ -96,20 +94,6 @@ void JetsonV4L2Capturer::OnCaptured(uint8_t* data, uint32_t bytesused) {
   }
 
   if (_captureVideoType == webrtc::VideoType::kMJPEG) {
-    unsigned int eosSearchSize = MJPEG_EOS_SEARCH_SIZE;
-    uint8_t* p;
-    /* v4l2_buf.bytesused may have padding bytes for alignment
-        Search for EOF to get exact size */
-    if (eosSearchSize > bytesused)
-      eosSearchSize = bytesused;
-    for (unsigned int i = 0; i < eosSearchSize; i++) {
-      p = data + bytesused;
-      if ((*(p - 2) == 0xff) && (*(p - 1) == 0xd9)) {
-        break;
-      }
-      bytesused--;
-    }
-
     auto decoder = jpeg_decoder_pool_->Pop();
     int fd = 0;
     uint32_t width, height, pixfmt;

--- a/src/hwenc_jetson/jetson_v4l2_capturer.cpp
+++ b/src/hwenc_jetson/jetson_v4l2_capturer.cpp
@@ -35,7 +35,7 @@ rtc::scoped_refptr<V4L2VideoCapturer> JetsonV4L2Capturer::Create(
 }
 
 bool JetsonV4L2Capturer::UseNativeBuffer() {
-  return true;  
+  return true;
 }
 
 rtc::scoped_refptr<V4L2VideoCapturer> JetsonV4L2Capturer::Create(
@@ -95,35 +95,39 @@ bool JetsonV4L2Capturer::OnCaptured(struct v4l2_buffer& buf) {
     return false;
   }
 
+  unsigned char* start = (unsigned char*)_pool[buf.index].start;
+  unsigned int bytesused = buf.bytesused;
   if (_captureVideoType == webrtc::VideoType::kMJPEG) {
-    unsigned int bytesused = buf.bytesused;
+    if (bytesused > 2 && !(start[0] == 0xff && start[1] == 0xd8)) {
+      RTC_LOG(LS_ERROR) << __FUNCTION__ << " Invalid JPEG buffer frame skipped";
+      return false;
+    }
+
     unsigned int eosSearchSize = MJPEG_EOS_SEARCH_SIZE;
-    uint8_t *p;
+    uint8_t* p;
     /* v4l2_buf.bytesused may have padding bytes for alignment
         Search for EOF to get exact size */
     if (eosSearchSize > bytesused)
-        eosSearchSize = bytesused;
+      eosSearchSize = bytesused;
     for (unsigned int i = 0; i < eosSearchSize; i++) {
-        p = (uint8_t *)_pool[buf.index].start + bytesused;
-        if ((*(p-2) == 0xff) && (*(p-1) == 0xd9)) {
-            break;
-        }
-        bytesused--;
+      p = start + bytesused;
+      if ((*(p - 2) == 0xff) && (*(p - 1) == 0xd9)) {
+        break;
+      }
+      bytesused--;
     }
 
     auto decoder = jpeg_decoder_pool_->Pop();
     int fd = 0;
     uint32_t width, height, pixfmt;
-    if (decoder->DecodeToFd(fd, (unsigned char *)_pool[buf.index].start,
-        bytesused, pixfmt, width, height) < 0) {
+    if (decoder->DecodeToFd(fd, start, bytesused, pixfmt, width, height) < 0) {
       RTC_LOG(LS_ERROR) << "decodeToFd Failed";
       return false;
     }
 
     rtc::scoped_refptr<JetsonBuffer> jetson_buffer(
-        JetsonBuffer::Create(
-            _captureVideoType, width, height, adapted_width, adapted_height,
-            fd, pixfmt, std::move(decoder)));
+        JetsonBuffer::Create(_captureVideoType, width, height, adapted_width,
+                             adapted_height, fd, pixfmt, std::move(decoder)));
     OnFrame(webrtc::VideoFrame::Builder()
                 .set_video_frame_buffer(jetson_buffer)
                 .set_timestamp_rtp(0)
@@ -134,12 +138,10 @@ bool JetsonV4L2Capturer::OnCaptured(struct v4l2_buffer& buf) {
 
   } else {
     rtc::scoped_refptr<JetsonBuffer> jetson_buffer(
-        JetsonBuffer::Create(
-            _captureVideoType, _currentWidth, _currentHeight,
-            adapted_width, adapted_height));
-    memcpy(jetson_buffer->Data(), (unsigned char*)_pool[buf.index].start,
-           buf.bytesused);
-    jetson_buffer->SetLength(buf.bytesused);
+        JetsonBuffer::Create(_captureVideoType, _currentWidth, _currentHeight,
+                             adapted_width, adapted_height));
+    memcpy(jetson_buffer->Data(), start, bytesused);
+    jetson_buffer->SetLength(bytesused);
     OnFrame(webrtc::VideoFrame::Builder()
                 .set_video_frame_buffer(jetson_buffer)
                 .set_timestamp_rtp(0)

--- a/src/hwenc_jetson/jetson_v4l2_capturer.h
+++ b/src/hwenc_jetson/jetson_v4l2_capturer.h
@@ -7,9 +7,11 @@
 
 class JetsonV4L2Capturer : public V4L2VideoCapturer {
  public:
-  static rtc::scoped_refptr<V4L2VideoCapturer> Create(V4L2VideoCapturerConfig config);
+  static rtc::scoped_refptr<V4L2VideoCapturer> Create(
+      V4L2VideoCapturerConfig config);
 
   bool UseNativeBuffer() override;
+
  private:
   static rtc::scoped_refptr<V4L2VideoCapturer> Create(
       webrtc::VideoCaptureModule::DeviceInfo* device_info,
@@ -18,7 +20,7 @@ class JetsonV4L2Capturer : public V4L2VideoCapturer {
 
   bool AllocateVideoBuffers() override;
   bool DeAllocateVideoBuffers() override;
-  bool OnCaptured(struct v4l2_buffer& buf) override;
+  void OnCaptured(uint8_t* data, uint32_t bytesused) override;
 
   std::shared_ptr<JetsonJpegDecoderPool> jpeg_decoder_pool_;
 };

--- a/src/hwenc_mmal/mmal_v4l2_capturer.h
+++ b/src/hwenc_mmal/mmal_v4l2_capturer.h
@@ -50,7 +50,7 @@ class MMALV4L2Capturer : public V4L2VideoCapturer {
   int32_t StartCapture(V4L2VideoCapturerConfig config) override;
   int32_t StopCapture() override;
   bool UseNativeBuffer() override;
-  bool OnCaptured(struct v4l2_buffer& buf) override;
+  void OnCaptured(uint8_t* data, uint32_t bytesused) override;
   static void MMALInputCallbackFunction(MMAL_PORT_T* port,
                                         MMAL_BUFFER_HEADER_T* buffer);
   void MMALInputCallback(MMAL_PORT_T* port, MMAL_BUFFER_HEADER_T* buffer);

--- a/src/v4l2_video_capturer/v4l2_video_capturer.h
+++ b/src/v4l2_video_capturer/v4l2_video_capturer.h
@@ -50,7 +50,7 @@ class V4L2VideoCapturer : public ScalableVideoTrackSource {
   virtual int32_t StopCapture();
   virtual bool AllocateVideoBuffers();
   virtual bool DeAllocateVideoBuffers();
-  virtual bool OnCaptured(struct v4l2_buffer& buf);
+  virtual void OnCaptured(uint8_t* data, uint32_t bytesused);
 
   int32_t _deviceFd;
   int32_t _currentWidth;


### PR DESCRIPTION
Jetson で不正な MJPEG フレームを USB カメラから受け取ってしまうと、 JPEG デコーダーがクラッシュして Momo ごと落ちてしまうため、ヘッダーをみて明らかに MJPEG でないものを後続処理に除外する処理を入れたいと思います。

主な対象 USB カメラは DELL WB7022 ですが、同一の OEM 元から複数供給されているようですので対策しておきたいと思います。