### PR TITLE
ubuntu で画面キャプチャが動かない問題を修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
     - @voluntas
 - [UPDATE] cmake を 3.22.2 に上げる
     - @voluntas
+- [FIX] スクリーンキャプチャが Linux で落ちるのを修正
+    - @tnoho
 
 
 ## 2021.6.0

--- a/src/rtc/screen_video_capturer.cpp
+++ b/src/rtc/screen_video_capturer.cpp
@@ -31,7 +31,7 @@ const std::string ScreenVideoCapturer::GetSourceListString() {
   if (GetSourceList(&sources)) {
     int i = 0;
     for (webrtc::DesktopCapturer::Source& source : sources) {
-      oss << i++ << " : " << source.title << std::endl;
+      oss << std::to_string(i++) << " : " << source.title << std::endl;
     }
   }
   return oss.str();

--- a/src/rtc/screen_video_capturer.cpp
+++ b/src/rtc/screen_video_capturer.cpp
@@ -31,6 +31,10 @@ const std::string ScreenVideoCapturer::GetSourceListString() {
   if (GetSourceList(&sources)) {
     int i = 0;
     for (webrtc::DesktopCapturer::Source& source : sources) {
+      // ubuntu で画面キャプチャが動かない問題への対策
+      // 原因は正しくつかめていないが std::to_string をはさむことで
+      // セグメンテーション違反となる処理を回避できているのか、
+      // クリーンインストールされた環境においては問題なく動作する。
       oss << std::to_string(i++) << " : " << source.title << std::endl;
     }
   }


### PR DESCRIPTION
ubuntu 18.04, 20.04 で画面キャプチャが動かない問題を修正します。

原因は正しくつかめていませんが、セグメンテーション違反となる処理を回避できているようなので、これでクリーンインストールされた環境においては問題なく動作するようです。