### PR TITLE
デコーダーからの情報で切り抜いていなかったので修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
     - @voluntas
 - [UPDATE] cmake を 3.22.2 に上げる
     - @voluntas
+- [FIX] Jetson のハードウェアデコーダーが出力時に出力サイズでフレームを切り抜いていなかったため修正
+    - @tnoho
 
 
 ## 2021.6.0

--- a/src/hwenc_jetson/jetson_video_decoder.cpp
+++ b/src/hwenc_jetson/jetson_video_decoder.cpp
@@ -236,7 +236,7 @@ void JetsonVideoDecoder::CaptureLoop() {
       if (errno == EAGAIN) {
         continue;
       } else {
-        RTC_LOG(LS_ERROR) << __FUNCTION__ << "Failed to dqEvent at decoder";
+        RTC_LOG(LS_ERROR) << __FUNCTION__ << " Failed to dqEvent at decoder";
         got_error_ = true;
         break;
       }
@@ -295,6 +295,7 @@ void JetsonVideoDecoder::CaptureLoop() {
       transform_params.transform_filter = NvBufferTransform_Filter_Smart;
       transform_params.src_rect = src_rect;
       transform_params.dst_rect = dest_rect;
+      // 何が来ても YUV420 に変換する
       ret = NvBufferTransform(buffer->planes[0].fd, dst_dma_fd_,
                               &transform_params);
       if (ret == -1) {

--- a/src/hwenc_jetson/jetson_video_decoder.cpp
+++ b/src/hwenc_jetson/jetson_video_decoder.cpp
@@ -370,9 +370,9 @@ int JetsonVideoDecoder::SetCapture() {
   ret = decoder_->capture_plane.getCrop(*capture_crop_.get());
   INIT_ERROR(ret < 0, "Failed to getCrop at capture_plane");
 
-  RTC_LOG(LS_ERROR) << __FUNCTION__ << " plane format " << format.fmt.pix_mp.pixelformat
+  RTC_LOG(LS_INFO) << __FUNCTION__ << " plane format " << format.fmt.pix_mp.pixelformat
                    << " " << format.fmt.pix_mp.width << "x" << format.fmt.pix_mp.height;
-  RTC_LOG(LS_ERROR) << __FUNCTION__ << " crop "
+  RTC_LOG(LS_INFO) << __FUNCTION__ << " crop "
                    << capture_crop_->c.top << "x" << capture_crop_->c.left
                    << " " << capture_crop_->c.width << "x" << format.fmt.pix_mp.height;
 

--- a/src/hwenc_jetson/jetson_video_decoder.h
+++ b/src/hwenc_jetson/jetson_video_decoder.h
@@ -54,6 +54,8 @@ class JetsonVideoDecoder : public webrtc::VideoDecoder {
   std::atomic<bool> eos_;
   std::atomic<bool> got_error_;
   int dst_dma_fd_;
+  int32_t width_;
+  int32_t height_;
 };
 
 #endif  // JETSON_VIDEO_DECODER_H_

--- a/src/hwenc_jetson/jetson_video_decoder.h
+++ b/src/hwenc_jetson/jetson_video_decoder.h
@@ -54,8 +54,7 @@ class JetsonVideoDecoder : public webrtc::VideoDecoder {
   std::atomic<bool> eos_;
   std::atomic<bool> got_error_;
   int dst_dma_fd_;
-  int32_t width_;
-  int32_t height_;
+  std::unique_ptr<v4l2_crop> capture_crop_;
 };
 
 #endif  // JETSON_VIDEO_DECODER_H_

--- a/src/sdl_renderer/sdl_renderer.cpp
+++ b/src/sdl_renderer/sdl_renderer.cpp
@@ -216,11 +216,13 @@ void SDLRenderer::Sink::OnFrame(const webrtc::VideoFrame& frame) {
     if (frame_aspect > outline_aspect_) {
       width = outline_width_;
       height = width / frame_aspect;
+      offset_x_ = 0;
       offset_y_ = (outline_height_ - height) / 2;
     } else {
       height = outline_height_;
       width = height * frame_aspect;
       offset_x_ = (outline_width_ - width) / 2;
+      offset_y_ = 0;
     }
     if (width_ != width || height_ != height) {
       width_ = width;


### PR DESCRIPTION
#124 #239 に対する修正です。

デコードしたフレームはその大きさをデコーダーから貰うべきなのですが、デコーダーから情報をもらってデコード済みのフレームに大きさをセットする処理が抜けていたため追記しました。