### PR TITLE
Offer 時は DataChannel を作る

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
     - @voluntas
 - [UPDATE] cmake を 3.22.2 に上げる
     - @voluntas
+- [ADD] DataChannel を使うことになっていて Offer を行う際には DataChannel を作るように変更
+    - @tnoho
 
 
 ## 2021.6.0

--- a/src/rtc/peer_connection_observer.cpp
+++ b/src/rtc/peer_connection_observer.cpp
@@ -10,6 +10,10 @@ PeerConnectionObserver::~PeerConnectionObserver() {
   ClearAllRegisteredTracks();
 }
 
+RTCDataManager* PeerConnectionObserver::DataManager() {
+  return data_manager_;
+}
+
 void PeerConnectionObserver::OnDataChannel(
     rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel) {
   if (data_manager_ != nullptr) {

--- a/src/rtc/peer_connection_observer.h
+++ b/src/rtc/peer_connection_observer.h
@@ -16,6 +16,8 @@ class PeerConnectionObserver : public webrtc::PeerConnectionObserver {
       : sender_(sender), receiver_(receiver), data_manager_(data_manager) {}
   ~PeerConnectionObserver();
 
+  RTCDataManager* DataManager();
+
  private:
   void OnSignalingChange(
       webrtc::PeerConnectionInterface::SignalingState new_state) override {}

--- a/src/rtc/rtc_connection.cpp
+++ b/src/rtc/rtc_connection.cpp
@@ -116,6 +116,18 @@ RTCConnection::~RTCConnection() {
 
 void RTCConnection::CreateOffer(OnCreateSuccessFunc on_success,
                                 OnCreateFailureFunc on_failure) {
+  // CreateOffer を行うのは Ayame だけのため、ここで Offer の場合には DataChannel を作ることとした
+  // Momo の性質上 ReOffer することは無いので問題ないと思われる
+  RTCDataManager* data_manager = observer_->DataManager();
+  if (data_manager != nullptr) {
+    webrtc::DataChannelInit config;
+    auto result = connection_->CreateDataChannelOrError("serial", &config);
+    if (!result.ok()) {
+      RTC_LOG(LS_ERROR) << "CreateDataChannel() failed: " << result.error().message();
+    }
+    data_manager->OnDataChannel(result.MoveValue());
+  }
+
   using RTCOfferAnswerOptions =
       webrtc::PeerConnectionInterface::RTCOfferAnswerOptions;
   RTCOfferAnswerOptions options = RTCOfferAnswerOptions();


### PR DESCRIPTION
#237 対応で CreateOffer 時に CreateDataChannel します。

チャンネル名は固定してありますが、そもそも Serial と DataChannel をつなぐ部分がチャンネル名で接続先の Serial を変えるような実装をしていないため支障ありません。

CreateOffer 時に DataManager があれば CreateDataChannel っていうのはちょっと雑な実装な気もしつつ、この位置で行えば変更が少なくて済むのと、 Ayame しか CreateOffer しませんし ReOffer することもないのでコマンドラインツールとしては許容範囲だと判断しました。

いつもは PR 作成前に動作検証するのですが、これはちょっと検証が大変なのでやっていません。時間があったらやってみます。