### PR TITLE
Feature/document update

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -51,7 +51,7 @@ NVENC が利用可能なビデオカードは以下で確認してください�
 
 ### 動作確認が取れたビデオカード
 
-**是非 Discord の #nvidia-video-codec-sdk チャネルまでご連絡ください**
+**是非 Discord の #momo-nvidia-video-codec-sdk チャネルまでご連絡ください**
 
 - GeForce GTX 1080 Ti
     - @melpon

--- a/doc/SETUP_JETSON.md
+++ b/doc/SETUP_JETSON.md
@@ -108,9 +108,9 @@ Sora Labo の利用申請や使用方法については [Sora Labo のドキュ�
 ```shell
 $ ./momo --hw-mjpeg-decoder true --framerate 30 --resolution 4K --log-level 2 sora \
     --signaling-url \
-        wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-        wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-        wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+        wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+        wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+        wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
     --channel-id shiguredo@sora-labo \
     --video true --audio true \
     --video-codec-type VP8 --video-bit-rate 15000 \

--- a/doc/SETUP_JETSON.md
+++ b/doc/SETUP_JETSON.md
@@ -107,7 +107,11 @@ Sora Labo の利用申請や使用方法については [Sora Labo のドキュ�
 
 ```shell
 $ ./momo --hw-mjpeg-decoder true --framerate 30 --resolution 4K --log-level 2 sora \
-    wss://sora-labo.shiguredo.jp/signaling shiguredo@sora-labo \
+    --signaling-url \
+        wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+        wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+        wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+    --channel-id shiguredo@sora-labo \
     --video true --audio true \
     --video-codec-type VP8 --video-bit-rate 15000 \
     --auto --role sendonly --multistream true \

--- a/doc/SETUP_WINDOWS.md
+++ b/doc/SETUP_WINDOWS.md
@@ -15,8 +15,13 @@ metadataオプションのキーや値を囲む「"」を「\\\"」にする必�
 
 PowerShell での実行例：
 ```
-.\momo.exe --no-audio-device sora `
-    wss://sora-labo.shiguredo.jp/signaling shiguredo@sora-labo `
+.\momo.exe --no-audio-device `
+    sora `
+        --signaling-url `
+             wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling `
+             wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling `
+             wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling `
+        --channel-id shiguredo@sora-labo `
         --video-codec-type VP8 --video-bit-rate 500 `
         --audio false `
         --role sendonly --metadata '{\"signaling_key\": \"xyz\"}'

--- a/doc/SETUP_WINDOWS.md
+++ b/doc/SETUP_WINDOWS.md
@@ -18,9 +18,9 @@ PowerShell での実行例：
 .\momo.exe --no-audio-device `
     sora `
         --signaling-url `
-             wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling `
-             wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling `
-             wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling `
+             wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling `
+             wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling `
+             wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling `
         --channel-id shiguredo@sora-labo `
         --video-codec-type VP8 --video-bit-rate 500 `
         --audio false `

--- a/doc/USE_AYAME.md
+++ b/doc/USE_AYAME.md
@@ -19,13 +19,13 @@ Ayame Labo はサインアップせずにシグナリングサーバを利用可
 ここではルーム ID は `open-momo` としておりますが、必ず推測されにくい値に変更してください。
 
 ```shell
-./momo --no-audio-device ayame wss://ayame-labo.shiguredo.jp/signaling open-momo
+./momo --no-audio-device ayame --signaling-url wss://ayame-labo.shiguredo.jp/signaling --channel-id open-momo
 ```
 
 Windows の場合:
 
 ```
-.\momo.exe --no-audio-device ayame wss://ayame-labo.shiguredo.jp/signaling open-momo
+.\momo.exe --no-audio-device ayame --signaling-url wss://ayame-labo.shiguredo.jp/signaling --channel-id open-momo
 ```
 
 
@@ -44,13 +44,13 @@ Ayame Labo にサインアップした場合はルーム ID に GitHub ユーザ
     - ここではシグナリングキーを `xyz` としています
 
 ```shell
-./momo --no-audio-device ayame wss://ayame-labo.shiguredo.jp/signaling shiguredo@open-momo --signaling-key xyz
+./momo --no-audio-device ayame --signaling-url wss://ayame-labo.shiguredo.jp/signaling --channel-id shiguredo@open-momo --signaling-key xyz
 ```
 
 Windows の場合:
 
 ```
-.\momo.exe --no-audio-device ayame wss://ayame-labo.shiguredo.jp/signaling shiguredo@open-momo --signaling-key xyz
+.\momo.exe --no-audio-device ayame --signaling-url wss://ayame-labo.shiguredo.jp/signaling --channel-id shiguredo@open-momo --signaling-key xyz
 ```
 
 Ayame SDK のオンラインサンプルを利用します。 URL の引数にルーム ID とシグナリングキーを指定してアクセスします。

--- a/doc/USE_SORA.md
+++ b/doc/USE_SORA.md
@@ -25,9 +25,9 @@ GitHub アカウントを用意して https://sora-labo.shiguredo.jp/ にサイ�
 ./momo --no-audio-device \
     sora \
         --signaling-url \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo@sora-labo \
         --video-codec-type VP8 --video-bit-rate 500 \
         --audio false \
@@ -44,9 +44,9 @@ GUI 環境で Momo を利用すると、 SDL を利用し音声や映像の受�
 ./momo --resolution VGA --no-audio-device --use-sdl --show-me \
     sora \
         --signaling-url \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo@open-momo \
         --video-codec-type VP8 --video-bit-rate 1000 \
         --audio false \
@@ -61,9 +61,9 @@ GUI 環境で Momo を利用すると、 SDL を利用し音声や映像の受�
 ./momo --no-audio-device \
     sora \
         --signaling-url \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
-            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterName>.sora.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo@sora-labo \
         --simulcast true \
         --video-codec-type VP8 --video-bit-rate 500 \

--- a/doc/USE_SORA.md
+++ b/doc/USE_SORA.md
@@ -25,9 +25,9 @@ GitHub アカウントを用意して https://sora-labo.shiguredo.jp/ にサイ�
 ./momo --no-audio-device \
     sora \
         --signaling-url \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo@sora-labo \
         --video-codec-type VP8 --video-bit-rate 500 \
         --audio false \
@@ -44,9 +44,9 @@ GUI 環境で Momo を利用すると、 SDL を利用し音声や映像の受�
 ./momo --resolution VGA --no-audio-device --use-sdl --show-me \
     sora \
         --signaling-url \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo@open-momo \
         --video-codec-type VP8 --video-bit-rate 1000 \
         --audio false \
@@ -61,9 +61,9 @@ GUI 環境で Momo を利用すると、 SDL を利用し音声や映像の受�
 ./momo --no-audio-device \
     sora \
         --signaling-url \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
-            wss://node-01.sora-labo.shiguredo.jp/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
+            wss://<IPv4Address>.<ClusterType>.sora.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo@sora-labo \
         --simulcast true \
         --video-codec-type VP8 --video-bit-rate 500 \


### PR DESCRIPTION
momo ドキュメントの見直し修正を行いました。それぞれの修正点は以下になります。

- FAQ.md の修正
   Discord チャンネルが古い指定のままだったため、現在のチャネルを記載しました。
- USE_SORA.md の修正
   コマンド例の Sora Labo の URL が以前のままだったため、修正しました。
- SETUP_WINDOWS.md の修正
    - 以前は momo でシグナリング URL を指定するときは URL だけで大丈夫でしたが、仕様変更により `--signaling-url` を使用するように変更となったため、コマンド例を修正しました。また SoraLabo の URL も修正しました。
    - シグナリング URL 同様、以前の momo ではチャネル ID もチャネル ID だけで大丈夫でしたが、仕様変更により `--channel-id` をプレフィックスするように変更になったため、修正しました。
- SETUP_JETSON.md の修正
   SETUP_WINDOWS.md の修正と同様の理由でコマンド例の修正をしました。
- USE_AYAME.md の修正
    - 以前は momo でシグナリング URL を指定するときは URL だけで大丈夫でしたが、仕様変更により `--signaling-url` を使用するように変更となったため、コマンド例を修正しました。
    - シグナリング URL 同様、以前の momo ではチャネル ID もチャネル ID だけで大丈夫でしたが、仕様変更により `--channel-id` を使用するように変更になったため、修正しました。
