### PR TITLE
FAQ.md の修正

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -120,11 +120,3 @@ Mac (arm64) から FHD でスクリーンキャプチャを配信したい場合
 
 NVIDIA のビデオカードの NVENC を利用することで H.264 が利用可能になります。
 ご利用の環境で H.264 が利用できるかどうかは `./momo --video-codec-engines` を使用して H264 の項目をご確認ください。
-
-## Jetson シリーズを使って SDL で Simulcast の H.264 を受信する
-
-Jetson シリーズで Simulcast の H.264 を SDL を使って受信する場合、下部に緑の線が見えることがあります。
-
-これは受信している Simulcast の解像度が H.264 の解像度の仕様に不一致な状態で受信しているためで、 Sora の API を使用して受信する解像度を変更してください。
-
-API の詳細はこちらの [Sora のドキュメント](https://sora-doc.shiguredo.jp/EXPERIMENTAL_API#adcbc8)をお読みください。


### PR DESCRIPTION
- 「Jetson シリーズを使って SDL で Simulcast の H.264 を受信する」について問題が解消されたため記載を削除しました。
    Release 2022.1.0 以降は Jetson のハードウェアデコーダーが出力時に出力サイズでフレームを切り抜くように修正されたため従来のように H.264 の解像度の仕様不一致で緑の線が出るようなことがなくなりました。