### PR TITLE
USE_TEST.md に記載されているコマンド例を修正

### DIFF
--- a/doc/USE_TEST.md
+++ b/doc/USE_TEST.md
@@ -33,7 +33,7 @@ Momo 1:
 Momo 2:
 
 ```shell
-./momo --use-sdl --show-me ayame ws://[Momo 1のIPアドレス]:8080/ws test
+./momo --use-sdl --show-me ayame  --signaling-url ws://[Momo 1のIPアドレス]:8080/ws --channel-id test
 ```
 
 Google STUN を利用したくない場合は`--no-google-stun`をオプションを追加することで可能になります。
@@ -47,7 +47,7 @@ Momo 1:
 Momo 2:
 
 ```shell
-./momo  --no-google-stun --use-sdl --show-me ayame ws://[Momo 1のIPアドレス]:8080/ws test
+./momo  --no-google-stun --use-sdl --show-me ayame --signaling-url ws://[Momo 1のIPアドレス]:8080/ws --channel-id test
 ```
 
 配信がうまくいくとそれぞれのマシンにお互いの映像と音声が出力されます。  


### PR DESCRIPTION
- momo 同士の接続で利用しているコマンド例のオプションが不足していたので修正しました
  momo 双方向の接続の際には一方は test モードでもう一方が ayame モードを利用するようにしています。 ayame モードは signaling-url と channel-id が必須のため、指定しないとエラーとなってしまいますのでコマンド例に追記しました。