### PR TITLE
rtc_connection.cpp の mid が設定されていなかった時に決め打ちしていた箇所を削除

### DIFF
--- a/src/rtc/rtc_connection.cpp
+++ b/src/rtc/rtc_connection.cpp
@@ -363,25 +363,10 @@ void RTCConnection::SetEncodingParameters(
   }
 
   rtc::scoped_refptr<webrtc::RtpTransceiverInterface> video_transceiver;
-  if (mid.empty()) {
-    // TODO(melpon): mid が手に入るようになったので、こっちの実装はそのうち消す
-
-    // setRD のあとの direction は recv only になる。
-    // 現状 sender.track.streamIds を取れないので connection ID との比較もできない。
-    // video upstream 持っているときは、ひとつめの video type transceiver を
-    // 自分が send すべき transceiver と決め打ちする。
-    for (auto transceiver : connection_->GetTransceivers()) {
-      if (transceiver->media_type() == cricket::MediaType::MEDIA_TYPE_VIDEO) {
-        video_transceiver = transceiver;
-        break;
-      }
-    }
-  } else {
-    for (auto transceiver : connection_->GetTransceivers()) {
-      if (transceiver->mid() && *transceiver->mid() == mid) {
-        video_transceiver = transceiver;
-        break;
-      }
+  for (auto transceiver : connection_->GetTransceivers()) {
+    if (transceiver->mid() && *transceiver->mid() == mid) {
+      video_transceiver = transceiver;
+      break;
     }
   }
 


### PR DESCRIPTION
これまでは mid が取得できなかったために video type transceiverを決め打ちで設定していました。
Sora の変更で mid が取得できるようになったため、決めうちの処理が不要となりましたので削除します。