### PR TITLE
--data-channel-signaling, --ignore-disconnect-websocket に none を指定できるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
     - @miosakuma
 - [UPDATE] `libwebrtc` を `M105.5195@{#0}` に上げる
     - @miosakuma
+- [FIX] `--data-channel-signaling`, `--ignore-disconnect-websocket` に 'none' を指定するとエラーになる問題を修正
+    - @miosakuma
 
 ## 2022.3.0
 


### PR DESCRIPTION
--data-channel-signaling, --ignore-disconnect-websocket に none を指定するとエラーになる問題を修正しました。

動作確認済みです。ソース内容等にコメントあればお願いいたします。


完了済みの過去のコメント
---

optional_bool_map の項目について none を指定するとエラーになるケースについて sora-cpp-sdk の対応を参考にして対応をしてみたのですが、コンパイルエラーのため 21 行目で `static void add_optional_bool` と static にしてしまっています。

https://github.com/shiguredo/momo/compare/feature/fix-optional-bool-map-none-error?expand=1#diff-449acf764318b0ca96972daf8d28a28af79ad2c3381044851f2953792fcd8eefR21

おそらくもっと private な宣言があると思うのですが対応方法を教えていただけますか。
C++ の基本がわかってなくて申しわけないです。

→
static を付けたままの方がと他の .cpp ファイルで同名の関数が定義できるので、ファイル内でしか使わないなら static で定義した方がよいとのことで static のままとする
