### PR TITLE
metadata に JSON にパースできない値を指定した時に異常終了する問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX] metadata に JSON にパースできない値を指定した時に異常終了する問題を修正する
+    - @miosakuma
+
 ## 2022.4.1
 
 - [FIX] CI で Windows の場合 $GITHUB_OUTPUT に "\r" が混入するのを除去する

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -367,7 +367,7 @@ void Util::ParseArgs(int argc,
   auto is_json = CLI::Validator(
       [](std::string input) -> std::string {
         boost::json::error_code ec;
-        boost::json::parse(input);
+        boost::json::parse(input, ec);
         if (ec) {
           return "Value " + input + " is not JSON Value";
         }


### PR DESCRIPTION
metadata に JSON 以外の値を指定したときに異常終了する問題を修正しました。
macos 版の momo で動作確認済みです。