### PR TITLE
Github Actions の Ubuntu を 20.04 にあげる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
           - ubuntu-18.04_armv8_jetson_xavier
           - ubuntu-20.04_x86_64
     name: Build momo for ${{ matrix.name }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Versions

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -79,7 +79,7 @@ jobs:
           - ubuntu-18.04_armv8_jetson_xavier
           - ubuntu-20.04_x86_64
     name: Build momo for ${{ matrix.name }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Versions


### PR DESCRIPTION
Github Actions の Ubuntu 18.04 サポート終了に伴い、20.04 に変更します。
https://github.com/actions/runner-images/issues/6002