### PR TITLE
Github Actions の download-artifact を v4 に上げる

### DIFF
--- a/.github/actions/download/action.yml
+++ b/.github/actions/download/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.platform }}.env
         path: ${{ inputs.platform }}.env
@@ -22,7 +22,7 @@ runs:
         echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
         echo "$PACKAGE_NAME/$PACKAGE_NAME" >> package_paths.env
       id: env
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ steps.env.outputs.package_name }}
         path: ${{ steps.env.outputs.package_name }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
 - [UPDATE] パッケージディレクトリ変更に追従する
   - WebRTC を m118 に上げた際にパッケージディレクトリが変更されたのでそれに追従する
   - @torikizi
+- [UPDATE] Github Actions の actions/download-artifact をアップデート
+  - Node.js 16 の Deprecated に伴うアップデート
+    - actions/download-artifact@v3 から actions/download-artifact@v4 にアップデート
+  - @torikizi
 
 ## 2023.1.0
 


### PR DESCRIPTION
CI が通りしだいマージします。