### PR TITLE
Sora モードの signaling-url オプションを signaling-urls に変更

### DIFF
--- a/doc/SETUP_JETSON.md
+++ b/doc/SETUP_JETSON.md
@@ -106,7 +106,7 @@ Sora Labo の利用申請や使用方法については [Sora Labo のドキュ�
 
 ```bash
 $ ./momo --hw-mjpeg-decoder true --framerate 30 --resolution 4K --log-level 2 sora \
-    --signaling-url \
+    --signaling-urls \
         wss://canary.sora-labo.shiguredo.app/signaling \
     --channel-id shiguredo_0_sora \
     --video true --audio true \

--- a/doc/SETUP_WINDOWS.md
+++ b/doc/SETUP_WINDOWS.md
@@ -18,7 +18,7 @@ PowerShell での実行例：
 ```console
 .\momo.exe --no-audio-device `
     sora `
-        --signaling-url `
+        --signaling-urls `
              wss://canary.sora-labo.shiguredo.app/signaling `
         --channel-id shiguredo_0_sora `
         --video-codec-type VP8 --video-bit-rate 500 `

--- a/doc/USE.md
+++ b/doc/USE.md
@@ -226,7 +226,7 @@ Usage: ./momo sora [OPTIONS]
 Options:
   -h,--help                   Print this help message and exit
   --help-all                  Print help message for all modes and exit
-  --signaling-url TEXT ... REQUIRED
+  --signaling-urls TEXT ... REQUIRED
                               Signaling URLs
   --channel-id TEXT REQUIRED  Channel ID
   --auto                      Connect to Sora automatically

--- a/doc/USE_SDL.md
+++ b/doc/USE_SDL.md
@@ -45,7 +45,7 @@ SDL (Simple DirectMedia Layer) を利用することで、 Momo 自体が受信�
 - Signaling サーバの URL はダミーです
 
 ```bash
-./momo --resolution VGA --no-audio-device --use-sdl sora --video-codec-type VP8 --video-bit-rate 1000 --audio false --signaling-url wss://example.com/signaling --channel-id momo-sdl-sora
+./momo --resolution VGA --no-audio-device --use-sdl sora --video-codec-type VP8 --video-bit-rate 1000 --audio false --signaling-urls wss://example.com/signaling --channel-id momo-sdl-sora
 ```
 
 [![Image from Gyazo](https://i.gyazo.com/abdb1802bd66440ef32e75da6842f0cf.png)](https://gyazo.com/abdb1802bd66440ef32e75da6842f0cf)

--- a/doc/USE_SORA.md
+++ b/doc/USE_SORA.md
@@ -25,7 +25,7 @@ GitHub アカウントを用意して <https://sora-labo.shiguredo.app/> にサ�
 ```bash
 ./momo --no-audio-device \
     sora \
-        --signaling-url \
+        --signaling-urls \
             wss://canary.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo_0_sora \
         --video-codec-type VP8 --video-bit-rate 500 \
@@ -42,7 +42,7 @@ GUI 環境で Momo を利用すると、 SDL を利用し音声や映像の受�
 ```bash
 ./momo --resolution VGA --no-audio-device --use-sdl \
     sora \
-        --signaling-url \
+        --signaling-urls \
             wss://canary.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo_0_sora \
         --video-codec-type VP8 --video-bit-rate 1000 \
@@ -57,7 +57,7 @@ GUI 環境で Momo を利用すると、 SDL を利用し音声や映像の受�
 ```bash
 ./momo --no-audio-device \
     sora \
-        --signaling-url \
+        --signaling-urls \
             wss://canary.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo_0_sora \
         --video-codec-type VP8 --video-bit-rate 500 \

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -253,7 +253,7 @@ void Util::ParseArgs(int argc,
                         "Signaling key");
 
   sora_app
-      ->add_option("--signaling-url", args.sora_signaling_urls,
+      ->add_option("--signaling-urls", args.sora_signaling_urls,
                    "Signaling URLs")
       ->take_all()
       ->required();


### PR DESCRIPTION
Sora モードの signaling-url オプションを signaling-urls に修正。
それに合わせて Sora モードの記載のある doc も修正しています。

macOS で動作も確認済みです。