### PR TITLE
Raspberry Pi ビルドを bookworm にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,16 +19,16 @@
   - @melpon
 - [CHANGE] ubuntu-20.04_armv8_jetson_xavier のパッケージを削除
   - @melpon
+- [CHANGE] JetPack 5.1.2 に対応
+  - JetPack 5.1.1, 5.1.2 で動作を確認
+  - JetPack 5.1 では、互換性の問題で JetsonJpegDecoder がエラーになることを確認
+  - @enm10k
 - [UPDATE] CLI11 を 2.4.2 に上げる
   - @voluntas @torikizi
 - [UPDATE] SDL を 2.30.3 に上げる
   - @voluntas @torikizi
 - [UPDATE] Boost を 1.85.0 に上げる
   - @torikizi
-- [CHANGE] JetPack 5.1.2 に対応
-  - JetPack 5.1.1, 5.1.2 で動作を確認
-  - JetPack 5.1 では、互換性の問題で JetsonJpegDecoder がエラーになることを確認
-  - @enm10k
 - [UPDATE] WebRTC を m125.6422.2.5 に上げる
   - @torikizi @melpon
 - [UPDATE] WebRTC を m119 に上げたことで必要になった関連するライブラリもバージョンを上げる
@@ -44,6 +44,14 @@
   - Node.js 16 の Deprecated に伴うアップデート
     - actions/download-artifact@v3 から actions/download-artifact@v4 にアップデート
   - @torikizi
+- [UPDATE] Raspberry Pi OS のビルドを bullseye から bookworm にアップデート
+  - multistrap の suite を bullseye から bookworm に修正
+  - libstdc++-11-dev をインストールするように修正
+  - @torikizi
+- [UPDATE] CMakeList.txt の修正
+  - STL が要求する CUDA のバージョンが 12.4 以上であるため、他のプラットフォームに影響が出ないように無視するように修正
+  - 参考: https://stackoverflow.com/questions/78515942/cuda-compatibility-with-visual-studio-2022-version-17-10
+  - @torikizi
 - [ADD] ubuntu-22.04_armv8_jetson のパッケージを追加
   - @melpon
 - [ADD] Intel VPL の H.265 ハードウェアエンコーダ/デコーダに対応する
@@ -58,14 +66,14 @@
   - @melpon
 - [ADD] Ubuntu 24.04 対応
   - @melpon
-- [FIX] macOS で USB 接続されたカメラが取得できなくなっていたのを修正
-  - macOS で USB デバイスが取得できなくなっていたため、取得するように修正
-  - macOS 14 以降では従来の API では取得できなくなっていたため API を新たに用意し、macOS 14 以降で新しい API を利用する
-  - @torikizi
 - [ADD] Intel VPL の AV1 ハードウェアエンコーダに対応する
   - @tnoho
 - [ADD] Intel VPL の VP9 ハードウェアエンコーダに対応する
   - @tnoho
+- [FIX] macOS で USB 接続されたカメラが取得できなくなっていたのを修正
+  - macOS で USB デバイスが取得できなくなっていたため、取得するように修正
+  - macOS 14 以降では従来の API では取得できなくなっていたため API を新たに用意し、macOS 14 以降で新しい API を利用する
+  - @torikizi
 
 ## 2023.1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,9 @@ if ("${TARGET_OS}" STREQUAL "windows")
         # VS のバージョンと _MSC_VER のリストは以下を参照:
         #   https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/
         -allow-unsupported-compiler
+        # 更に STL が CUDA 12.4 以上のバージョンを要求するため、STL のバージョンも無視する
+        # ref: https://stackoverflow.com/questions/78515942/cuda-compatibility-with-visual-studio-2022-version-17-10
+        -Xcompiler /D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
         -Xcompiler /utf-8
         -Xcompiler /I${CMAKE_CURRENT_SOURCE_DIR}/third_party/NvCodec/include
         -Xcompiler /I${CMAKE_CURRENT_SOURCE_DIR}/third_party/NvCodec/NvCodec

--- a/multistrap/raspberry-pi-os_armv8.conf
+++ b/multistrap/raspberry-pi-os_armv8.conf
@@ -4,7 +4,7 @@ bootstrap=Deb Rasp
 aptsources=Deb Rasp
 
 [Deb]
-packages=libc6-dev libstdc++-10-dev libasound2-dev libpulse-dev libudev-dev libexpat1-dev libnss3-dev libxext-dev libxtst-dev
+packages=libc6-dev libstdc++-11-dev libasound2-dev libpulse-dev libudev-dev libexpat1-dev libnss3-dev libxext-dev libxtst-dev
 source=http://deb.debian.org/debian
 suite=bookworm
 

--- a/multistrap/raspberry-pi-os_armv8.conf
+++ b/multistrap/raspberry-pi-os_armv8.conf
@@ -6,9 +6,9 @@ aptsources=Deb Rasp
 [Deb]
 packages=libc6-dev libstdc++-10-dev libasound2-dev libpulse-dev libudev-dev libexpat1-dev libnss3-dev libxext-dev libxtst-dev
 source=http://deb.debian.org/debian
-suite=bullseye
+suite=bookworm
 
 [Rasp]
 packages=libcamera-dev
 source=http://archive.raspberrypi.org/debian
-suite=bullseye
+suite=bookworm


### PR DESCRIPTION
Raspberry Pi のビルドを bookworm ベースにアップデートしました。
また、Windows のビルドについて修正をしました。

---
This pull request includes several updates and fixes across multiple components, primarily focusing on compatibility improvements and version updates. The most important changes are summarized below:

### Compatibility and Version Updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R22-L31): Added support for JetPack 5.1.2, including verification for JetPack 5.1.1 and 5.1.2, and noted compatibility issues with JetPack 5.1 causing errors in `JetsonJpegDecoder`.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R47-R54): Updated the build for Raspberry Pi OS from `bullseye` to `bookworm`, including modifications to `multistrap` suite and installation of `libstdc++-11-dev`.
* [`multistrap/raspberry-pi-os_armv8.conf`](diffhunk://#diff-7dfbb6bb4ca7f32cabe12d3d01a151f5ff8ac10e31d01d9c07ebf8b49f90e975L7-R14): Changed the suite from `bullseye` to `bookworm` and updated the package `libstdc++-10-dev` to `libstdc++-11-dev`.

### Bug Fixes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L61-R76): Fixed an issue where USB-connected cameras were not being detected on macOS, particularly addressing changes in macOS 14 by introducing a new API.

### Build Configuration:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR341-R343): Added a compiler flag to ignore the STL version requirement for CUDA 12.4 or higher to prevent issues on other platforms.