### PR TITLE
Intel VPL の VP9 エンコーダーでキーフレーム要求が機能しない問題を修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,10 @@
   - AfMode, AfRange, AfSpeed などの enum 型コントロールに対応
   - 文字列ベースでコントロールを設定できる API を実装
   - @voluntas
+- [FIX] Intel VPL の VP9 エンコーダーでキーフレーム要求が機能しない問題を修正
+  - VP9 では `MFX_FRAMETYPE_I` のみを設定するように修正
+  - `MFX_FRAMETYPE_REF` や `MFX_FRAMETYPE_IDR` を同時に設定すると vpl-gpu-rt の CheckAndFixCtrl で `MFX_FRAMETYPE_P` に変更されてしまうため
+  - @voluntas
 
 ### misc
 

--- a/src/sora-cpp-sdk/src/hwenc_vpl/vpl_video_encoder.cpp
+++ b/src/sora-cpp-sdk/src/hwenc_vpl/vpl_video_encoder.cpp
@@ -472,7 +472,15 @@ int32_t VplVideoEncoderImpl::Encode(
   mfxEncodeCtrl ctrl;
   memset(&ctrl, 0, sizeof(ctrl));
   if (send_key_frame) {
-    ctrl.FrameType = MFX_FRAMETYPE_I | MFX_FRAMETYPE_IDR | MFX_FRAMETYPE_REF;
+    // VP9 では MFX_FRAMETYPE_I のみを設定する
+    // VP9 は MFX_FRAMETYPE_I か MFX_FRAMETYPE_P のみのフレームを想定しているようで、
+    // 他のフレームタイプを設定すると内部的に MFX_FRAMETYPE_P に変更されてしまう
+    // ref: https://github.com/intel/vpl-gpu-rt/blob/5d99334834aafc5448e7c799a7c176ee0832ec09/_studio/mfx_lib/encode_hw/vp9/src/mfx_vp9_encode_hw_par.cpp#L1853-L1857
+    if (codec_ == MFX_CODEC_VP9) {
+      ctrl.FrameType = MFX_FRAMETYPE_I;
+    } else {
+      ctrl.FrameType = MFX_FRAMETYPE_I | MFX_FRAMETYPE_IDR | MFX_FRAMETYPE_REF;
+    }
   } else {
     ctrl.FrameType = MFX_FRAMETYPE_UNKNOWN;
   }


### PR DESCRIPTION
VP9 では MFX_FRAMETYPE_I のみを設定するように修正。
MFX_FRAMETYPE_REF や MFX_FRAMETYPE_IDR を同時に設定すると
vpl-gpu-rt の CheckAndFixCtrl で MFX_FRAMETYPE_P に変更されてしまうため。